### PR TITLE
feat(security): Phase B 보안 강화 — JWT 환경변수화, CORS, 보안 헤더, Brute-Force 방어, 예외 catch-all

### DIFF
--- a/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/AnalyticsDashboardRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/AnalyticsDashboardRepository.java
@@ -3,6 +3,7 @@ package com.smartfirehub.analytics.repository;
 import static org.jooq.impl.DSL.*;
 
 import com.smartfirehub.analytics.dto.CreateDashboardRequest;
+import com.smartfirehub.global.util.LikePatternUtils;
 import com.smartfirehub.analytics.dto.DashboardResponse;
 import com.smartfirehub.analytics.dto.UpdateDashboardRequest;
 import java.time.LocalDateTime;
@@ -55,8 +56,9 @@ public class AnalyticsDashboardRepository {
     conditions.add(D_CREATED_BY.eq(userId).or(D_IS_SHARED.isTrue()));
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(D_NAME.likeIgnoreCase(pattern).or(D_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          D_NAME.likeIgnoreCase(pattern, '\\').or(D_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     Condition combined = conditions.stream().reduce(Condition::and).orElse(trueCondition());
@@ -93,8 +95,9 @@ public class AnalyticsDashboardRepository {
     conditions.add(D_CREATED_BY.eq(userId).or(D_IS_SHARED.isTrue()));
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(D_NAME.likeIgnoreCase(pattern).or(D_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          D_NAME.likeIgnoreCase(pattern, '\\').or(D_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     Condition combined = conditions.stream().reduce(Condition::and).orElse(trueCondition());

--- a/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/ChartRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/ChartRepository.java
@@ -3,6 +3,7 @@ package com.smartfirehub.analytics.repository;
 import static org.jooq.impl.DSL.*;
 
 import com.smartfirehub.analytics.dto.ChartResponse;
+import com.smartfirehub.global.util.LikePatternUtils;
 import com.smartfirehub.analytics.dto.CreateChartRequest;
 import com.smartfirehub.analytics.dto.UpdateChartRequest;
 import java.time.LocalDateTime;
@@ -74,8 +75,9 @@ public class ChartRepository {
     conditions.add(C_CREATED_BY.eq(userId).or(C_IS_SHARED.isTrue()));
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(C_NAME.likeIgnoreCase(pattern).or(C_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          C_NAME.likeIgnoreCase(pattern, '\\').or(C_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     if (chartType != null && !chartType.isBlank()) {
@@ -126,8 +128,9 @@ public class ChartRepository {
     conditions.add(C_CREATED_BY.eq(userId).or(C_IS_SHARED.isTrue()));
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(C_NAME.likeIgnoreCase(pattern).or(C_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          C_NAME.likeIgnoreCase(pattern, '\\').or(C_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     if (chartType != null && !chartType.isBlank()) {

--- a/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/SavedQueryRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/analytics/repository/SavedQueryRepository.java
@@ -3,6 +3,7 @@ package com.smartfirehub.analytics.repository;
 import static org.jooq.impl.DSL.*;
 
 import com.smartfirehub.analytics.dto.CreateSavedQueryRequest;
+import com.smartfirehub.global.util.LikePatternUtils;
 import com.smartfirehub.analytics.dto.SavedQueryListResponse;
 import com.smartfirehub.analytics.dto.SavedQueryResponse;
 import com.smartfirehub.analytics.dto.UpdateSavedQueryRequest;
@@ -84,8 +85,11 @@ public class SavedQueryRepository {
     }
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(SQ_NAME.likeIgnoreCase(pattern).or(SQ_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          SQ_NAME
+              .likeIgnoreCase(pattern, '\\')
+              .or(SQ_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     if (folder != null && !folder.isBlank()) {
@@ -147,8 +151,11 @@ public class SavedQueryRepository {
     }
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search + "%";
-      conditions.add(SQ_NAME.likeIgnoreCase(pattern).or(SQ_DESCRIPTION.likeIgnoreCase(pattern)));
+      String pattern = LikePatternUtils.containsPattern(search);
+      conditions.add(
+          SQ_NAME
+              .likeIgnoreCase(pattern, '\\')
+              .or(SQ_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     if (folder != null && !folder.isBlank()) {

--- a/apps/firehub-api/src/main/java/com/smartfirehub/audit/repository/AuditLogRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/audit/repository/AuditLogRepository.java
@@ -4,6 +4,7 @@ import static org.jooq.impl.DSL.*;
 
 import com.smartfirehub.audit.dto.AuditLogResponse;
 import com.smartfirehub.global.dto.PageResponse;
+import com.smartfirehub.global.util.LikePatternUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -152,10 +153,12 @@ public class AuditLogRepository {
     Condition condition = noCondition();
 
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search.trim() + "%";
+      String pattern = LikePatternUtils.containsPattern(search.trim());
       condition =
           condition.and(
-              AL_USERNAME.likeIgnoreCase(pattern).or(AL_DESCRIPTION.likeIgnoreCase(pattern)));
+              AL_USERNAME
+                  .likeIgnoreCase(pattern, '\\')
+                  .or(AL_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
 
     if (actionType != null && !actionType.isBlank()) {

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/controller/AuthController.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/controller/AuthController.java
@@ -81,7 +81,7 @@ public class AuthController {
         ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
             .httpOnly(true)
             .secure(true)
-            .sameSite("Strict")
+            .sameSite("Lax")
             .path(REFRESH_TOKEN_PATH)
             .maxAge(jwtProperties.refreshExpiration() / 1000)
             .build();
@@ -93,7 +93,7 @@ public class AuthController {
         ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
             .httpOnly(true)
             .secure(true)
-            .sameSite("Strict")
+            .sameSite("Lax")
             .path(REFRESH_TOKEN_PATH)
             .maxAge(0)
             .build();

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/LoginRequest.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/LoginRequest.java
@@ -1,6 +1,5 @@
 package com.smartfirehub.auth.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record LoginRequest(@NotBlank @Email String username, @NotBlank String password) {}
+public record LoginRequest(@NotBlank String username, @NotBlank String password) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/RefreshTokenRequest.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/RefreshTokenRequest.java
@@ -1,5 +1,0 @@
-package com.smartfirehub.auth.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record RefreshTokenRequest(@NotBlank String refreshToken) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/SignupRequest.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/dto/SignupRequest.java
@@ -2,10 +2,17 @@ package com.smartfirehub.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
     @NotBlank @Email String username,
     @Email String email,
-    @NotBlank @Size(min = 8, max = 128) String password,
+    @NotBlank
+        @Size(min = 8, max = 128)
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$",
+            message =
+                "Password must contain at least one uppercase letter, one lowercase letter, and one digit")
+        String password,
     @NotBlank String name) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/exception/AccountLockedException.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/exception/AccountLockedException.java
@@ -1,0 +1,7 @@
+package com.smartfirehub.auth.exception;
+
+public class AccountLockedException extends RuntimeException {
+  public AccountLockedException(String message) {
+    super(message);
+  }
+}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/repository/RefreshTokenRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/repository/RefreshTokenRepository.java
@@ -1,13 +1,19 @@
 package com.smartfirehub.auth.repository;
 
 import static com.smartfirehub.jooq.Tables.*;
+import static org.jooq.impl.DSL.field;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class RefreshTokenRepository {
+
+  private static final Field<UUID> FAMILY_ID = field("family_id", UUID.class);
 
   private final DSLContext dsl;
 
@@ -15,11 +21,12 @@ public class RefreshTokenRepository {
     this.dsl = dsl;
   }
 
-  public void save(Long userId, String tokenHash, LocalDateTime expiresAt) {
+  public void save(Long userId, String tokenHash, LocalDateTime expiresAt, UUID familyId) {
     dsl.insertInto(REFRESH_TOKEN)
         .set(REFRESH_TOKEN.USER_ID, userId)
         .set(REFRESH_TOKEN.TOKEN_HASH, tokenHash)
         .set(REFRESH_TOKEN.EXPIRES_AT, expiresAt)
+        .set(FAMILY_ID, familyId)
         .execute();
   }
 
@@ -32,10 +39,33 @@ public class RefreshTokenRepository {
             .and(REFRESH_TOKEN.EXPIRES_AT.gt(LocalDateTime.now())));
   }
 
+  public boolean isTokenRevoked(String tokenHash) {
+    return dsl.fetchExists(
+        dsl.selectOne()
+            .from(REFRESH_TOKEN)
+            .where(REFRESH_TOKEN.TOKEN_HASH.eq(tokenHash))
+            .and(REFRESH_TOKEN.REVOKED.eq(true)));
+  }
+
+  public Optional<UUID> findFamilyIdByTokenHash(String tokenHash) {
+    return dsl.select(FAMILY_ID)
+        .from(REFRESH_TOKEN)
+        .where(REFRESH_TOKEN.TOKEN_HASH.eq(tokenHash))
+        .fetchOptional(FAMILY_ID);
+  }
+
   public void revokeByTokenHash(String tokenHash) {
     dsl.update(REFRESH_TOKEN)
         .set(REFRESH_TOKEN.REVOKED, true)
         .where(REFRESH_TOKEN.TOKEN_HASH.eq(tokenHash))
+        .execute();
+  }
+
+  public void revokeByFamilyId(UUID familyId) {
+    dsl.update(REFRESH_TOKEN)
+        .set(REFRESH_TOKEN.REVOKED, true)
+        .where(FAMILY_ID.eq(familyId))
+        .and(REFRESH_TOKEN.REVOKED.eq(false))
         .execute();
   }
 
@@ -44,6 +74,20 @@ public class RefreshTokenRepository {
         .set(REFRESH_TOKEN.REVOKED, true)
         .where(REFRESH_TOKEN.USER_ID.eq(userId))
         .and(REFRESH_TOKEN.REVOKED.eq(false))
+        .execute();
+  }
+
+  public int deleteExpiredTokens() {
+    return dsl.deleteFrom(REFRESH_TOKEN)
+        .where(
+            REFRESH_TOKEN
+                .EXPIRES_AT
+                .lt(LocalDateTime.now())
+                .or(
+                    REFRESH_TOKEN
+                        .REVOKED
+                        .eq(true)
+                        .and(REFRESH_TOKEN.CREATED_AT.lt(LocalDateTime.now().minusDays(7)))))
         .execute();
   }
 }

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/AuthService.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/AuthService.java
@@ -64,6 +64,7 @@ public class AuthService {
       throw new EmailAlreadyExistsException("Email already exists: " + request.email());
     }
 
+    userRepository.acquireFirstUserLock();
     boolean isFirstUser = userRepository.countAll(null) == 0;
 
     String encodedPassword = passwordEncoder.encode(request.password());
@@ -146,6 +147,10 @@ public class AuthService {
         userRepository
             .findById(userId)
             .orElseThrow(() -> new InvalidTokenException("User not found for token"));
+
+    if (!user.isActive()) {
+      throw new UserDeactivatedException("User account is deactivated");
+    }
 
     String accessToken = jwtTokenProvider.generateAccessToken(user.id(), user.username());
     String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.id());

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/LoginAttemptService.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/LoginAttemptService.java
@@ -1,0 +1,30 @@
+package com.smartfirehub.auth.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginAttemptService {
+
+  private static final int MAX_ATTEMPTS = 5;
+  private static final int LOCK_DURATION_MINUTES = 15;
+
+  private final Cache<String, Integer> attemptsCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(LOCK_DURATION_MINUTES)).build();
+
+  public void loginFailed(String username) {
+    Integer attempts = attemptsCache.getIfPresent(username);
+    attemptsCache.put(username, (attempts == null ? 0 : attempts) + 1);
+  }
+
+  public void loginSucceeded(String username) {
+    attemptsCache.invalidate(username);
+  }
+
+  public boolean isBlocked(String username) {
+    Integer attempts = attemptsCache.getIfPresent(username);
+    return attempts != null && attempts >= MAX_ATTEMPTS;
+  }
+}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/RefreshTokenCleanupService.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/auth/service/RefreshTokenCleanupService.java
@@ -1,0 +1,26 @@
+package com.smartfirehub.auth.service;
+
+import com.smartfirehub.auth.repository.RefreshTokenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefreshTokenCleanupService {
+
+  private static final Logger log = LoggerFactory.getLogger(RefreshTokenCleanupService.class);
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  public RefreshTokenCleanupService(RefreshTokenRepository refreshTokenRepository) {
+    this.refreshTokenRepository = refreshTokenRepository;
+  }
+
+  /** Delete expired tokens and revoked tokens older than 7 days. Runs daily at 4 AM. */
+  @Scheduled(cron = "0 0 4 * * *")
+  public void cleanupExpiredTokens() {
+    int deleted = refreshTokenRepository.deleteExpiredTokens();
+    log.info("Cleaned up {} expired/revoked refresh tokens", deleted);
+  }
+}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/dataset/repository/DatasetRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/dataset/repository/DatasetRepository.java
@@ -3,6 +3,7 @@ package com.smartfirehub.dataset.repository;
 import static org.jooq.impl.DSL.*;
 
 import com.smartfirehub.dataset.dto.CategoryResponse;
+import com.smartfirehub.global.util.LikePatternUtils;
 import com.smartfirehub.dataset.dto.CreateDatasetRequest;
 import com.smartfirehub.dataset.dto.DatasetResponse;
 import com.smartfirehub.dataset.dto.UpdateDatasetRequest;
@@ -166,16 +167,16 @@ public class DatasetRepository {
       condition = condition.and(DS_STATUS.eq(status));
     }
     if (search != null && !search.isBlank()) {
-      String pattern = "%" + search.toLowerCase() + "%";
+      String pattern = LikePatternUtils.containsPattern(search);
       condition =
           condition.and(
               DS_NAME
-                  .likeIgnoreCase(pattern)
-                  .or(DS_DESCRIPTION.likeIgnoreCase(pattern))
-                  .or(DS_TABLE_NAME.likeIgnoreCase(pattern))
-                  .or(COL_COLUMN_NAME.likeIgnoreCase(pattern))
-                  .or(COL_DISPLAY_NAME.likeIgnoreCase(pattern))
-                  .or(COL_DESCRIPTION.likeIgnoreCase(pattern)));
+                  .likeIgnoreCase(pattern, '\\')
+                  .or(DS_DESCRIPTION.likeIgnoreCase(pattern, '\\'))
+                  .or(DS_TABLE_NAME.likeIgnoreCase(pattern, '\\'))
+                  .or(COL_COLUMN_NAME.likeIgnoreCase(pattern, '\\'))
+                  .or(COL_DISPLAY_NAME.likeIgnoreCase(pattern, '\\'))
+                  .or(COL_DESCRIPTION.likeIgnoreCase(pattern, '\\')));
     }
     return condition;
   }

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/config/CorsProperties.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/config/CorsProperties.java
@@ -1,0 +1,7 @@
+package com.smartfirehub.global.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(List<String> allowedOrigins) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/config/SecurityConfig.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/config/SecurityConfig.java
@@ -3,9 +3,11 @@ package com.smartfirehub.global.config;
 import com.smartfirehub.global.security.JwtAuthenticationFilter;
 import com.smartfirehub.global.security.JwtProperties;
 import jakarta.servlet.DispatcherType;
+import java.util.List;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,21 +15,35 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class})
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final CorsProperties corsProperties;
 
-  public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+  public SecurityConfig(
+      JwtAuthenticationFilter jwtAuthenticationFilter, CorsProperties corsProperties) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.corsProperties = corsProperties;
   }
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.disable())
+    http.cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.disable())
+        .headers(
+            headers ->
+                headers
+                    .contentTypeOptions(Customizer.withDefaults())
+                    .frameOptions(frame -> frame.deny())
+                    .httpStrictTransportSecurity(
+                        hsts -> hsts.includeSubDomains(true).maxAgeInSeconds(31536000)))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
@@ -46,6 +62,25 @@ public class SecurityConfig {
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    List<String> origins = corsProperties.allowedOrigins();
+    if (origins != null) {
+      List<String> filtered = origins.stream().filter(o -> o != null && !o.isBlank()).toList();
+      if (!filtered.isEmpty()) {
+        config.setAllowedOrigins(filtered);
+      }
+    }
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+    config.setMaxAge(3600L);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/api/**", config);
+    return source;
   }
 
   @Bean

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/dto/ErrorResponse.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/dto/ErrorResponse.java
@@ -2,4 +2,6 @@ package com.smartfirehub.global.dto;
 
 import java.util.Map;
 
-public record ErrorResponse(int status, String error, String message, Map<String, String> errors) {}
+public record ErrorResponse(
+    int status, String error, String message, Map<String, String> errors,
+    String timestamp, String path) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/exception/GlobalExceptionHandler.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.smartfirehub.global.exception;
 
 import com.smartfirehub.ai.exception.AiSessionNotFoundException;
 import com.smartfirehub.analytics.exception.ChartNotFoundException;
+import com.smartfirehub.auth.exception.AccountLockedException;
 import com.smartfirehub.analytics.exception.DashboardNotFoundException;
 import com.smartfirehub.analytics.exception.SavedQueryNotFoundException;
 import com.smartfirehub.apiconnection.exception.ApiConnectionException;
@@ -27,6 +28,8 @@ import com.smartfirehub.user.exception.UserNotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +40,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleValidationExceptions(
@@ -335,5 +340,25 @@ public class GlobalExceptionHandler {
     ErrorResponse response =
         new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+  }
+
+  @ExceptionHandler(AccountLockedException.class)
+  public ResponseEntity<ErrorResponse> handleAccountLocked(AccountLockedException ex) {
+    ErrorResponse response =
+        new ErrorResponse(
+            HttpStatus.TOO_MANY_REQUESTS.value(), "Too Many Requests", ex.getMessage(), null);
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(response);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+    log.error("Unhandled exception", ex);
+    ErrorResponse response =
+        new ErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            "Internal Server Error",
+            "An unexpected error occurred",
+            null);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 }

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/exception/GlobalExceptionHandler.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/exception/GlobalExceptionHandler.java
@@ -25,6 +25,8 @@ import com.smartfirehub.role.exception.RoleNotFoundException;
 import com.smartfirehub.role.exception.SystemRoleModificationException;
 import com.smartfirehub.user.exception.UserDeactivatedException;
 import com.smartfirehub.user.exception.UserNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,51 +45,57 @@ public class GlobalExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
+  private ErrorResponse buildError(
+      HttpStatus status, String message, Map<String, String> errors,
+      HttpServletRequest request) {
+    return new ErrorResponse(
+        status.value(), status.getReasonPhrase(), message, errors,
+        Instant.now().toString(), request.getRequestURI());
+  }
+
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleValidationExceptions(
-      MethodArgumentNotValidException ex) {
+      MethodArgumentNotValidException ex, HttpServletRequest request) {
     Map<String, String> fieldErrors = new HashMap<>();
     ex.getBindingResult()
         .getFieldErrors()
         .forEach(error -> fieldErrors.put(error.getField(), error.getDefaultMessage()));
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.BAD_REQUEST.value(), "Bad Request", "Validation failed", fieldErrors);
+        buildError(HttpStatus.BAD_REQUEST, "Validation failed", fieldErrors, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(UsernameAlreadyExistsException.class)
   public ResponseEntity<ErrorResponse> handleUsernameAlreadyExists(
-      UsernameAlreadyExistsException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", ex.getMessage(), null);
+      UsernameAlreadyExistsException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(EmailAlreadyExistsException.class)
-  public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(
+      EmailAlreadyExistsException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(InvalidCredentialsException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "Unauthorized", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleInvalidCredentials(
+      InvalidCredentialsException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.UNAUTHORIZED, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
   }
 
   @ExceptionHandler(InvalidTokenException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidToken(InvalidTokenException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "Unauthorized", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleInvalidToken(
+      InvalidTokenException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.UNAUTHORIZED, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)
   public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(
-      DataIntegrityViolationException ex) {
+      DataIntegrityViolationException ex, HttpServletRequest request) {
     String message = "Data integrity violation";
     if (ex.getCause() != null) {
       String causeMsg = ex.getCause().getMessage();
@@ -101,264 +109,245 @@ public class GlobalExceptionHandler {
         message = "Data integrity violation: " + causeMsg;
       }
     }
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", message, null);
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, message, null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.FORBIDDEN.value(), "Forbidden", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleAccessDenied(
+      AccessDeniedException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.FORBIDDEN, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
   }
 
   @ExceptionHandler(UserNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleUserNotFound(
+      UserNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(RoleNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleRoleNotFound(RoleNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleRoleNotFound(
+      RoleNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(SystemRoleModificationException.class)
   public ResponseEntity<ErrorResponse> handleSystemRoleModification(
-      SystemRoleModificationException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+      SystemRoleModificationException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(UserDeactivatedException.class)
-  public ResponseEntity<ErrorResponse> handleUserDeactivated(UserDeactivatedException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "Unauthorized", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleUserDeactivated(
+      UserDeactivatedException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.UNAUTHORIZED, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
   }
 
   @ExceptionHandler(DatasetNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleDatasetNotFound(DatasetNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleDatasetNotFound(
+      DatasetNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(CategoryNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleCategoryNotFound(CategoryNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleCategoryNotFound(
+      CategoryNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(DuplicateDatasetNameException.class)
   public ResponseEntity<ErrorResponse> handleDuplicateDatasetName(
-      DuplicateDatasetNameException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", ex.getMessage(), null);
+      DuplicateDatasetNameException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(InvalidTableNameException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidTableName(InvalidTableNameException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleInvalidTableName(
+      InvalidTableNameException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(ColumnModificationException.class)
-  public ResponseEntity<ErrorResponse> handleColumnModification(ColumnModificationException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleColumnModification(
+      ColumnModificationException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(ImportValidationException.class)
-  public ResponseEntity<ErrorResponse> handleImportValidation(ImportValidationException ex) {
+  public ResponseEntity<ErrorResponse> handleImportValidation(
+      ImportValidationException ex, HttpServletRequest request) {
     Map<String, String> errorMap = new HashMap<>();
     List<String> errors = ex.getErrors();
     for (int i = 0; i < errors.size(); i++) {
       errorMap.put("error_" + i, errors.get(i));
     }
     ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), errorMap);
+        buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), errorMap, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(ConcurrentImportException.class)
-  public ResponseEntity<ErrorResponse> handleConcurrentImport(ConcurrentImportException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleConcurrentImport(
+      ConcurrentImportException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(UnsupportedFileTypeException.class)
-  public ResponseEntity<ErrorResponse> handleUnsupportedFileType(UnsupportedFileTypeException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleUnsupportedFileType(
+      UnsupportedFileTypeException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(PipelineNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handlePipelineNotFound(PipelineNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handlePipelineNotFound(
+      PipelineNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(CyclicDependencyException.class)
-  public ResponseEntity<ErrorResponse> handleCyclicDependency(CyclicDependencyException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleCyclicDependency(
+      CyclicDependencyException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(ScriptExecutionException.class)
-  public ResponseEntity<ErrorResponse> handleScriptExecution(ScriptExecutionException ex) {
+  public ResponseEntity<ErrorResponse> handleScriptExecution(
+      ScriptExecutionException ex, HttpServletRequest request) {
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            "Internal Server Error",
-            ex.getMessage(),
-            null);
+        buildError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 
   @ExceptionHandler(com.smartfirehub.dataset.exception.SqlQueryException.class)
   public ResponseEntity<ErrorResponse> handleSqlQuery(
-      com.smartfirehub.dataset.exception.SqlQueryException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+      com.smartfirehub.dataset.exception.SqlQueryException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(com.smartfirehub.dataset.exception.RowNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleRowNotFound(
-      com.smartfirehub.dataset.exception.RowNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+      com.smartfirehub.dataset.exception.RowNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Bad Request", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleIllegalArgument(
+      IllegalArgumentException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), null, request);
     return ResponseEntity.badRequest().body(response);
   }
 
   @ExceptionHandler(AiSessionNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleAiSessionNotFound(AiSessionNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleAiSessionNotFound(
+      AiSessionNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(TriggerNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleTriggerNotFound(TriggerNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleTriggerNotFound(
+      TriggerNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(CyclicTriggerDependencyException.class)
   public ResponseEntity<ErrorResponse> handleCyclicTriggerDependency(
-      CyclicTriggerDependencyException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.CONFLICT.value(), "Conflict", ex.getMessage(), null);
+      CyclicTriggerDependencyException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.CONFLICT, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
   }
 
   @ExceptionHandler(CryptoException.class)
-  public ResponseEntity<ErrorResponse> handleCrypto(CryptoException ex) {
+  public ResponseEntity<ErrorResponse> handleCrypto(
+      CryptoException ex, HttpServletRequest request) {
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            "Internal Server Error",
-            ex.getMessage(),
-            null);
+        buildError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 
   @ExceptionHandler(SerializationException.class)
-  public ResponseEntity<ErrorResponse> handleSerialization(SerializationException ex) {
+  public ResponseEntity<ErrorResponse> handleSerialization(
+      SerializationException ex, HttpServletRequest request) {
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            "Internal Server Error",
-            ex.getMessage(),
-            null);
+        buildError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 
   @ExceptionHandler(ExternalServiceException.class)
-  public ResponseEntity<ErrorResponse> handleExternalService(ExternalServiceException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_GATEWAY.value(), "Bad Gateway", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleExternalService(
+      ExternalServiceException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.BAD_GATEWAY, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(response);
   }
 
   @ExceptionHandler(ImportProcessingException.class)
-  public ResponseEntity<ErrorResponse> handleImportProcessing(ImportProcessingException ex) {
+  public ResponseEntity<ErrorResponse> handleImportProcessing(
+      ImportProcessingException ex, HttpServletRequest request) {
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            "Internal Server Error",
-            ex.getMessage(),
-            null);
+        buildError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 
   @ExceptionHandler(ApiConnectionException.class)
-  public ResponseEntity<ErrorResponse> handleApiConnectionNotFound(ApiConnectionException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleApiConnectionNotFound(
+      ApiConnectionException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(SavedQueryNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleSavedQueryNotFound(SavedQueryNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleSavedQueryNotFound(
+      SavedQueryNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(ChartNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleChartNotFound(ChartNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleChartNotFound(
+      ChartNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(DashboardNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleDashboardNotFound(DashboardNotFoundException ex) {
-    ErrorResponse response =
-        new ErrorResponse(HttpStatus.NOT_FOUND.value(), "Not Found", ex.getMessage(), null);
+  public ResponseEntity<ErrorResponse> handleDashboardNotFound(
+      DashboardNotFoundException ex, HttpServletRequest request) {
+    ErrorResponse response = buildError(HttpStatus.NOT_FOUND, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(AccountLockedException.class)
-  public ResponseEntity<ErrorResponse> handleAccountLocked(AccountLockedException ex) {
+  public ResponseEntity<ErrorResponse> handleAccountLocked(
+      AccountLockedException ex, HttpServletRequest request) {
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.TOO_MANY_REQUESTS.value(), "Too Many Requests", ex.getMessage(), null);
+        buildError(HttpStatus.TOO_MANY_REQUESTS, ex.getMessage(), null, request);
     return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(response);
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+  public ResponseEntity<ErrorResponse> handleException(
+      Exception ex, HttpServletRequest request) {
     log.error("Unhandled exception", ex);
     ErrorResponse response =
-        new ErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
-            "Internal Server Error",
-            "An unexpected error occurred",
-            null);
+        buildError(
+            HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred", null, request);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 }

--- a/apps/firehub-api/src/main/java/com/smartfirehub/global/util/LikePatternUtils.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/global/util/LikePatternUtils.java
@@ -1,0 +1,50 @@
+package com.smartfirehub.global.util;
+
+/**
+ * Utility for safely escaping user input used in SQL LIKE patterns. Escapes the LIKE wildcard
+ * characters %, _, and the escape character \ itself.
+ *
+ * <p>Usage with jOOQ:
+ *
+ * <pre>
+ *   String pattern = LikePatternUtils.containsPattern(search);
+ *   field.likeIgnoreCase(pattern, '\\')
+ * </pre>
+ */
+public final class LikePatternUtils {
+
+  private static final char ESCAPE_CHAR = '\\';
+
+  private LikePatternUtils() {}
+
+  /**
+   * Escape LIKE special characters (%, _, \) in the given input string.
+   *
+   * @param input the raw user input to escape
+   * @return the escaped string safe for use in LIKE patterns
+   */
+  public static String escape(String input) {
+    if (input == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder(input.length() + 8);
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if (c == '%' || c == '_' || c == ESCAPE_CHAR) {
+        sb.append(ESCAPE_CHAR);
+      }
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Build a "contains" LIKE pattern: %escaped_input%.
+   *
+   * @param input the raw user search input
+   * @return pattern string for use with {@code .likeIgnoreCase(pattern, '\\')}
+   */
+  public static String containsPattern(String input) {
+    return "%" + escape(input) + "%";
+  }
+}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/role/repository/RoleRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/role/repository/RoleRepository.java
@@ -87,11 +87,14 @@ public class RoleRepository {
   public void setPermissions(Long roleId, List<Long> permissionIds) {
     dsl.deleteFrom(ROLE_PERMISSION).where(ROLE_PERMISSION.ROLE_ID.eq(roleId)).execute();
 
-    for (Long permissionId : permissionIds) {
-      dsl.insertInto(ROLE_PERMISSION)
-          .set(ROLE_PERMISSION.ROLE_ID, roleId)
-          .set(ROLE_PERMISSION.PERMISSION_ID, permissionId)
-          .execute();
+    if (!permissionIds.isEmpty()) {
+      var insert =
+          dsl.insertInto(
+              ROLE_PERMISSION, ROLE_PERMISSION.ROLE_ID, ROLE_PERMISSION.PERMISSION_ID);
+      for (Long permissionId : permissionIds) {
+        insert = insert.values(roleId, permissionId);
+      }
+      insert.execute();
     }
   }
 

--- a/apps/firehub-api/src/main/java/com/smartfirehub/role/service/RoleService.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/role/service/RoleService.java
@@ -77,9 +77,16 @@ public class RoleService {
 
   @Transactional
   public void setRolePermissions(Long roleId, List<Long> permissionIds) {
-    roleRepository
-        .findById(roleId)
-        .orElseThrow(() -> new RoleNotFoundException("Role not found: " + roleId));
+    RoleResponse role =
+        roleRepository
+            .findById(roleId)
+            .orElseThrow(() -> new RoleNotFoundException("Role not found: " + roleId));
+
+    if (role.isSystem()) {
+      throw new SystemRoleModificationException(
+          "Cannot modify permissions of system role: " + role.name());
+    }
+
     roleRepository.setPermissions(roleId, permissionIds);
   }
 }

--- a/apps/firehub-api/src/main/java/com/smartfirehub/settings/repository/SettingsRepository.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/settings/repository/SettingsRepository.java
@@ -2,6 +2,7 @@ package com.smartfirehub.settings.repository;
 
 import static org.jooq.impl.DSL.*;
 
+import com.smartfirehub.global.util.LikePatternUtils;
 import com.smartfirehub.settings.dto.SettingResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,7 +35,7 @@ public class SettingsRepository {
   public List<SettingResponse> findByPrefix(String prefix) {
     return dsl.select(KEY, VALUE, DESCRIPTION, UPDATED_AT)
         .from(SYSTEM_SETTINGS)
-        .where(KEY.like(prefix + ".%"))
+        .where(KEY.like(LikePatternUtils.escape(prefix) + ".%", '\\'))
         .orderBy(KEY)
         .fetch(
             r ->

--- a/apps/firehub-api/src/main/java/com/smartfirehub/user/dto/ChangePasswordRequest.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/user/dto/ChangePasswordRequest.java
@@ -1,7 +1,15 @@
 package com.smartfirehub.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChangePasswordRequest(
-    @NotBlank String currentPassword, @NotBlank @Size(min = 8, max = 128) String newPassword) {}
+    @NotBlank String currentPassword,
+    @NotBlank
+        @Size(min = 8, max = 128)
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$",
+            message =
+                "Password must contain at least one uppercase letter, one lowercase letter, and one digit")
+        String newPassword) {}

--- a/apps/firehub-api/src/main/java/com/smartfirehub/user/dto/UserResponse.java
+++ b/apps/firehub-api/src/main/java/com/smartfirehub/user/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package com.smartfirehub.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record UserResponse(
@@ -8,4 +9,4 @@ public record UserResponse(
     String email,
     String name,
     boolean isActive,
-    LocalDateTime createdAt) {}
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime createdAt) {}

--- a/apps/firehub-api/src/main/resources/application-local.yml
+++ b/apps/firehub-api/src/main/resources/application-local.yml
@@ -12,10 +12,12 @@ org:
 
 app:
   jwt:
-    secret: dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQga2V5IGZvciBIUzI1NiBhbGdvcml0aG0gdGhhdCBpcyBhdCBsZWFzdCAyNTYgYml0cw==
+    secret: ${JWT_SECRET:ZGV2LW9ubHktand0LXNlY3JldC1rZXktdGhpcy1pcy1ub3QtZm9yLXByb2R1Y3Rpb24tdXNl}
   encryption:
-    master-key: bG9jYWwtZGV2LW1hc3Rlci1rZXktZm9yLWVuY3J5cHQ=
+    master-key: ${ENCRYPTION_MASTER_KEY:bG9jYWwtZGV2LW1hc3Rlci1rZXktZm9yLWVuY3J5cHQ=}
+  cors:
+    allowed-origins: http://localhost:5173,http://localhost:3001
 
 agent:
   url: http://127.0.0.1:3001
-  internal-token: firehub-internal-secret-token
+  internal-token: ${AGENT_INTERNAL_TOKEN:firehub-local-dev-internal-token}

--- a/apps/firehub-api/src/main/resources/application-prod.yml
+++ b/apps/firehub-api/src/main/resources/application-prod.yml
@@ -9,6 +9,10 @@ org:
     dashboard:
       enabled: false
 
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
 agent:
   url: http://ai-agent:3001
   internal-token: ${AGENT_INTERNAL_TOKEN}

--- a/apps/firehub-api/src/main/resources/application.yml
+++ b/apps/firehub-api/src/main/resources/application.yml
@@ -29,3 +29,5 @@ app:
     refresh-expiration: 604800000
   encryption:
     master-key: ${ENCRYPTION_MASTER_KEY}
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}

--- a/apps/firehub-api/src/main/resources/db/migration/V28__add_refresh_token_family.sql
+++ b/apps/firehub-api/src/main/resources/db/migration/V28__add_refresh_token_family.sql
@@ -1,0 +1,11 @@
+-- Add family_id to refresh_token for token rotation with reuse detection.
+-- Tokens in the same family share a family_id; reuse of a revoked token
+-- triggers revocation of the entire family.
+
+ALTER TABLE refresh_token ADD COLUMN family_id UUID;
+
+UPDATE refresh_token SET family_id = gen_random_uuid() WHERE family_id IS NULL;
+
+ALTER TABLE refresh_token ALTER COLUMN family_id SET NOT NULL;
+
+CREATE INDEX idx_refresh_token_family_id ON refresh_token(family_id);

--- a/apps/firehub-api/src/test/java/com/smartfirehub/ai/service/AiSessionServiceTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/ai/service/AiSessionServiceTest.java
@@ -26,7 +26,7 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void getSessions_returnsSessionsForUser() {
     UserResponse user =
         authService.signup(
-            new SignupRequest("testuser", "test@example.com", "password123", "Test User"));
+            new SignupRequest("testuser", "test@example.com", "Password123", "Test User"));
     Long userId = user.id();
 
     aiSessionService.createSession(
@@ -43,7 +43,7 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void createSession_success() {
     UserResponse user =
         authService.signup(
-            new SignupRequest("testuser", "test@example.com", "password123", "Test User"));
+            new SignupRequest("testuser", "test@example.com", "Password123", "Test User"));
     Long userId = user.id();
 
     AiSessionResponse result =
@@ -64,7 +64,7 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void verifySessionOwnership_ownSession_noException() {
     UserResponse user =
         authService.signup(
-            new SignupRequest("testuser", "test@example.com", "password123", "Test User"));
+            new SignupRequest("testuser", "test@example.com", "Password123", "Test User"));
     Long userId = user.id();
 
     aiSessionService.createSession(
@@ -78,10 +78,10 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void verifySessionOwnership_otherUser_throwsAccessDenied() {
     UserResponse user1 =
         authService.signup(
-            new SignupRequest("user1", "user1@example.com", "password123", "User 1"));
+            new SignupRequest("user1", "user1@example.com", "Password123", "User 1"));
     UserResponse user2 =
         authService.signup(
-            new SignupRequest("user2", "user2@example.com", "password123", "User 2"));
+            new SignupRequest("user2", "user2@example.com", "Password123", "User 2"));
 
     aiSessionService.createSession(
         user1.id(), new CreateAiSessionRequest("session-u1", null, null, "User1 Session"));
@@ -94,7 +94,7 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void updateSessionTitle_ownSession_success() {
     UserResponse user =
         authService.signup(
-            new SignupRequest("testuser", "test@example.com", "password123", "Test User"));
+            new SignupRequest("testuser", "test@example.com", "Password123", "Test User"));
     Long userId = user.id();
 
     AiSessionResponse created =
@@ -112,10 +112,10 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void updateSessionTitle_otherUser_throwsAccessDenied() {
     UserResponse user1 =
         authService.signup(
-            new SignupRequest("user1", "user1@example.com", "password123", "User 1"));
+            new SignupRequest("user1", "user1@example.com", "Password123", "User 1"));
     UserResponse user2 =
         authService.signup(
-            new SignupRequest("user2", "user2@example.com", "password123", "User 2"));
+            new SignupRequest("user2", "user2@example.com", "Password123", "User 2"));
 
     AiSessionResponse created =
         aiSessionService.createSession(
@@ -130,7 +130,7 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void deleteSession_ownSession_success() {
     UserResponse user =
         authService.signup(
-            new SignupRequest("testuser", "test@example.com", "password123", "Test User"));
+            new SignupRequest("testuser", "test@example.com", "Password123", "Test User"));
     Long userId = user.id();
 
     AiSessionResponse created =
@@ -147,10 +147,10 @@ class AiSessionServiceTest extends IntegrationTestBase {
   void deleteSession_otherUser_throwsAccessDenied() {
     UserResponse user1 =
         authService.signup(
-            new SignupRequest("user1", "user1@example.com", "password123", "User 1"));
+            new SignupRequest("user1", "user1@example.com", "Password123", "User 1"));
     UserResponse user2 =
         authService.signup(
-            new SignupRequest("user2", "user2@example.com", "password123", "User 2"));
+            new SignupRequest("user2", "user2@example.com", "Password123", "User 2"));
 
     AiSessionResponse created =
         aiSessionService.createSession(

--- a/apps/firehub-api/src/test/java/com/smartfirehub/auth/controller/AuthControllerTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/auth/controller/AuthControllerTest.java
@@ -49,7 +49,7 @@ class AuthControllerTest {
   @Test
   void signup_returnsCreated() throws Exception {
     SignupRequest request =
-        new SignupRequest("test@example.com", "test@example.com", "password123", "Test User");
+        new SignupRequest("test@example.com", "test@example.com", "Password123", "Test User");
     UserResponse response =
         new UserResponse(
             1L, "test@example.com", "test@example.com", "Test User", true, LocalDateTime.now());
@@ -68,7 +68,7 @@ class AuthControllerTest {
 
   @Test
   void signup_invalidEmail_returnsBadRequest() throws Exception {
-    SignupRequest request = new SignupRequest("not-email", "not-email", "password123", "Test User");
+    SignupRequest request = new SignupRequest("not-email", "not-email", "Password123", "Test User");
 
     mockMvc
         .perform(
@@ -80,7 +80,7 @@ class AuthControllerTest {
 
   @Test
   void login_returnsOkWithCookie() throws Exception {
-    LoginRequest request = new LoginRequest("test@example.com", "password123");
+    LoginRequest request = new LoginRequest("test@example.com", "Password123");
     TokenResponse tokenResponse =
         new TokenResponse("access-token", "refresh-token", "Bearer", 1800);
 
@@ -121,7 +121,7 @@ class AuthControllerTest {
 
   @Test
   void login_accountLocked_returns429() throws Exception {
-    LoginRequest request = new LoginRequest("locked@example.com", "password123");
+    LoginRequest request = new LoginRequest("locked@example.com", "Password123");
 
     when(authService.login(any(LoginRequest.class)))
         .thenThrow(

--- a/apps/firehub-api/src/test/java/com/smartfirehub/auth/service/LoginAttemptServiceTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/auth/service/LoginAttemptServiceTest.java
@@ -1,0 +1,57 @@
+package com.smartfirehub.auth.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoginAttemptServiceTest {
+
+  private LoginAttemptService loginAttemptService;
+
+  @BeforeEach
+  void setUp() {
+    loginAttemptService = new LoginAttemptService();
+  }
+
+  @Test
+  void isBlocked_returnsFalse_whenNoAttempts() {
+    assertFalse(loginAttemptService.isBlocked("user@test.com"));
+  }
+
+  @Test
+  void isBlocked_returnsFalse_whenBelowMaxAttempts() {
+    for (int i = 0; i < 4; i++) {
+      loginAttemptService.loginFailed("user@test.com");
+    }
+    assertFalse(loginAttemptService.isBlocked("user@test.com"));
+  }
+
+  @Test
+  void isBlocked_returnsTrue_afterMaxAttempts() {
+    for (int i = 0; i < 5; i++) {
+      loginAttemptService.loginFailed("user@test.com");
+    }
+    assertTrue(loginAttemptService.isBlocked("user@test.com"));
+  }
+
+  @Test
+  void loginSucceeded_resetsAttempts() {
+    for (int i = 0; i < 5; i++) {
+      loginAttemptService.loginFailed("user@test.com");
+    }
+    assertTrue(loginAttemptService.isBlocked("user@test.com"));
+
+    loginAttemptService.loginSucceeded("user@test.com");
+    assertFalse(loginAttemptService.isBlocked("user@test.com"));
+  }
+
+  @Test
+  void isBlocked_isolatesUsernames() {
+    for (int i = 0; i < 5; i++) {
+      loginAttemptService.loginFailed("blocked@test.com");
+    }
+    assertTrue(loginAttemptService.isBlocked("blocked@test.com"));
+    assertFalse(loginAttemptService.isBlocked("other@test.com"));
+  }
+}

--- a/apps/firehub-api/src/test/java/com/smartfirehub/auth/service/RefreshTokenCleanupServiceTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/auth/service/RefreshTokenCleanupServiceTest.java
@@ -1,0 +1,87 @@
+package com.smartfirehub.auth.service;
+
+import static com.smartfirehub.jooq.Tables.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jooq.impl.DSL.field;
+
+import com.smartfirehub.auth.dto.LoginRequest;
+import com.smartfirehub.auth.dto.SignupRequest;
+import com.smartfirehub.auth.dto.TokenResponse;
+import com.smartfirehub.support.IntegrationTestBase;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class RefreshTokenCleanupServiceTest extends IntegrationTestBase {
+
+  private static final Field<UUID> FAMILY_ID = field("family_id", UUID.class);
+
+  @Autowired private RefreshTokenCleanupService cleanupService;
+
+  @Autowired private AuthService authService;
+
+  @Autowired private DSLContext dsl;
+
+  @Test
+  void cleanupExpiredTokens_deletesExpiredTokens() {
+    authService.signup(
+        new SignupRequest("test@example.com", "test@example.com", "Password123", "Test User"));
+    TokenResponse loginResult =
+        authService.login(new LoginRequest("test@example.com", "Password123"));
+
+    // Manually expire the token
+    dsl.update(REFRESH_TOKEN)
+        .set(REFRESH_TOKEN.EXPIRES_AT, LocalDateTime.now().minusDays(1))
+        .execute();
+
+    int before =
+        dsl.fetchCount(dsl.selectFrom(REFRESH_TOKEN));
+    assertThat(before).isGreaterThan(0);
+
+    cleanupService.cleanupExpiredTokens();
+
+    int after =
+        dsl.fetchCount(dsl.selectFrom(REFRESH_TOKEN));
+    assertThat(after).isEqualTo(0);
+  }
+
+  @Test
+  void cleanupExpiredTokens_deletesOldRevokedTokens() {
+    authService.signup(
+        new SignupRequest("test@example.com", "test@example.com", "Password123", "Test User"));
+    authService.login(new LoginRequest("test@example.com", "Password123"));
+
+    // Revoke all tokens and backdate created_at
+    dsl.update(REFRESH_TOKEN)
+        .set(REFRESH_TOKEN.REVOKED, true)
+        .set(REFRESH_TOKEN.CREATED_AT, LocalDateTime.now().minusDays(8))
+        .execute();
+
+    cleanupService.cleanupExpiredTokens();
+
+    int after =
+        dsl.fetchCount(dsl.selectFrom(REFRESH_TOKEN));
+    assertThat(after).isEqualTo(0);
+  }
+
+  @Test
+  void cleanupExpiredTokens_keepsValidTokens() {
+    authService.signup(
+        new SignupRequest("test@example.com", "test@example.com", "Password123", "Test User"));
+    authService.login(new LoginRequest("test@example.com", "Password123"));
+
+    int before =
+        dsl.fetchCount(dsl.selectFrom(REFRESH_TOKEN));
+
+    cleanupService.cleanupExpiredTokens();
+
+    int after =
+        dsl.fetchCount(dsl.selectFrom(REFRESH_TOKEN));
+    assertThat(after).isEqualTo(before);
+  }
+}

--- a/apps/firehub-api/src/test/java/com/smartfirehub/global/exception/ExceptionStubController.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/global/exception/ExceptionStubController.java
@@ -1,6 +1,7 @@
 package com.smartfirehub.global.exception;
 
 import com.smartfirehub.ai.exception.AiSessionNotFoundException;
+import com.smartfirehub.auth.exception.AccountLockedException;
 import com.smartfirehub.auth.exception.EmailAlreadyExistsException;
 import com.smartfirehub.auth.exception.InvalidCredentialsException;
 import com.smartfirehub.auth.exception.InvalidTokenException;
@@ -115,6 +116,16 @@ public class ExceptionStubController {
   @GetMapping("/data-integrity-violation")
   public void dataIntegrityViolation() {
     throw new DataIntegrityViolationException("Integrity error");
+  }
+
+  @GetMapping("/account-locked")
+  public void accountLocked() {
+    throw new AccountLockedException("Too many failed login attempts. Please try again later.");
+  }
+
+  @GetMapping("/unexpected-error")
+  public void unexpectedError() {
+    throw new RuntimeException("Something unexpected happened");
   }
 
   @PostMapping("/method-argument-not-valid")

--- a/apps/firehub-api/src/test/java/com/smartfirehub/global/exception/GlobalExceptionHandlerTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/global/exception/GlobalExceptionHandlerTest.java
@@ -218,4 +218,26 @@ class GlobalExceptionHandlerTest {
         .andExpect(jsonPath("$.message").value("Validation failed"))
         .andExpect(jsonPath("$.errors.name").isNotEmpty());
   }
+
+  @Test
+  void accountLocked_returns429() throws Exception {
+    mockMvc
+        .perform(get("/test/exception/account-locked"))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.status").value(429))
+        .andExpect(jsonPath("$.error").value("Too Many Requests"))
+        .andExpect(
+            jsonPath("$.message")
+                .value("Too many failed login attempts. Please try again later."));
+  }
+
+  @Test
+  void unexpectedError_returns500_withGenericMessage() throws Exception {
+    mockMvc
+        .perform(get("/test/exception/unexpected-error"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.status").value(500))
+        .andExpect(jsonPath("$.error").value("Internal Server Error"))
+        .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+  }
 }

--- a/apps/firehub-api/src/test/java/com/smartfirehub/global/util/LikePatternUtilsTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/global/util/LikePatternUtilsTest.java
@@ -1,0 +1,53 @@
+package com.smartfirehub.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LikePatternUtilsTest {
+
+  @Test
+  void escape_noSpecialChars_returnsUnchanged() {
+    assertThat(LikePatternUtils.escape("hello")).isEqualTo("hello");
+  }
+
+  @Test
+  void escape_percentSign_isEscaped() {
+    assertThat(LikePatternUtils.escape("100%")).isEqualTo("100\\%");
+  }
+
+  @Test
+  void escape_underscore_isEscaped() {
+    assertThat(LikePatternUtils.escape("user_name")).isEqualTo("user\\_name");
+  }
+
+  @Test
+  void escape_backslash_isEscaped() {
+    assertThat(LikePatternUtils.escape("path\\to")).isEqualTo("path\\\\to");
+  }
+
+  @Test
+  void escape_allSpecialChars_areEscaped() {
+    assertThat(LikePatternUtils.escape("%_\\")).isEqualTo("\\%\\_\\\\");
+  }
+
+  @Test
+  void escape_null_returnsNull() {
+    assertThat(LikePatternUtils.escape(null)).isNull();
+  }
+
+  @Test
+  void escape_empty_returnsEmpty() {
+    assertThat(LikePatternUtils.escape("")).isEmpty();
+  }
+
+  @Test
+  void containsPattern_wrapsWithPercent() {
+    assertThat(LikePatternUtils.containsPattern("test")).isEqualTo("%test%");
+  }
+
+  @Test
+  void containsPattern_escapesBeforeWrapping() {
+    assertThat(LikePatternUtils.containsPattern("100%_done")).isEqualTo("%100\\%\\_done%");
+  }
+}

--- a/apps/firehub-api/src/test/java/com/smartfirehub/user/controller/UserControllerTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/user/controller/UserControllerTest.java
@@ -89,7 +89,7 @@ class UserControllerTest {
   @Test
   void changePassword_authenticated_returnsNoContent() throws Exception {
     mockAuthentication("user:write:self");
-    ChangePasswordRequest request = new ChangePasswordRequest("oldpassword", "newpassword123");
+    ChangePasswordRequest request = new ChangePasswordRequest("oldpassword", "newPassword123");
 
     mockMvc
         .perform(
@@ -99,7 +99,7 @@ class UserControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isNoContent());
 
-    verify(userService).changePassword(1L, "oldpassword", "newpassword123");
+    verify(userService).changePassword(1L, "oldpassword", "newPassword123");
   }
 
   @Test

--- a/apps/firehub-api/src/test/java/com/smartfirehub/user/service/UserServiceTest.java
+++ b/apps/firehub-api/src/test/java/com/smartfirehub/user/service/UserServiceTest.java
@@ -34,7 +34,7 @@ class UserServiceTest extends IntegrationTestBase {
     testUserId =
         dsl.insertInto(USER)
             .set(USER.USERNAME, "testuser@example.com")
-            .set(USER.PASSWORD, passwordEncoder.encode("password123"))
+            .set(USER.PASSWORD, passwordEncoder.encode("Password123"))
             .set(USER.NAME, "Test User")
             .set(USER.EMAIL, "test@example.com")
             .returning(USER.ID)
@@ -101,7 +101,7 @@ class UserServiceTest extends IntegrationTestBase {
 
   @Test
   void changePassword_success() {
-    userService.changePassword(testUserId, "password123", "newpassword");
+    userService.changePassword(testUserId, "Password123", "newpassword");
 
     String storedPassword =
         dsl.select(USER.PASSWORD).from(USER).where(USER.ID.eq(testUserId)).fetchOne(USER.PASSWORD);

--- a/apps/firehub-api/src/test/resources/application-test.yml
+++ b/apps/firehub-api/src/test/resources/application-test.yml
@@ -18,6 +18,8 @@ app:
     refresh-expiration: 604800000
   encryption:
     master-key: dGVzdC1lbmNyeXB0aW9uLWtleS0zMmJ5dGVzLWhlcmU=
+  cors:
+    allowed-origins: http://localhost:5173
 
 agent:
   url: http://localhost:9999

--- a/apps/firehub-web/eslint.config.js
+++ b/apps/firehub-web/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -15,9 +16,16 @@ export default defineConfig([
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
     },
   },
 ])

--- a/apps/firehub-web/package.json
+++ b/apps/firehub-web/package.json
@@ -62,6 +62,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.5.0",
     "rollup-plugin-visualizer": "^7.0.0",
     "shadcn": "^3.8.4",

--- a/apps/firehub-web/src/App.tsx
+++ b/apps/firehub-web/src/App.tsx
@@ -1,11 +1,12 @@
-import { Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { AuthProvider } from './hooks/AuthContext';
-import { ProtectedRoute } from './components/ProtectedRoute';
+import { lazy,Suspense } from 'react';
+import { BrowserRouter, Route,Routes } from 'react-router-dom';
+
 import { AdminRoute } from './components/AdminRoute';
 import { AppLayout } from './components/layout/AppLayout';
-import { Toaster } from './components/ui/sonner';
+import { ProtectedRoute } from './components/ProtectedRoute';
 import { Skeleton } from './components/ui/skeleton';
+import { Toaster } from './components/ui/sonner';
+import { AuthProvider } from './hooks/AuthContext';
 
 // Lazy-loaded pages
 const LoginPage = lazy(() => import('./pages/LoginPage'));

--- a/apps/firehub-web/src/api/ai.ts
+++ b/apps/firehub-web/src/api/ai.ts
@@ -1,5 +1,5 @@
+import type { AIMessage, AISession, AIStreamEvent } from '../types/ai';
 import { client, getAccessToken } from './client';
-import type { AISession, AIMessage, AIStreamEvent } from '../types/ai';
 
 export const aiApi = {
   getSessions: (params?: { page?: number; size?: number }) =>

--- a/apps/firehub-web/src/api/analytics.ts
+++ b/apps/firehub-web/src/api/analytics.ts
@@ -1,26 +1,26 @@
-import { client } from './client';
 import type {
-  SavedQuery,
-  SavedQueryListItem,
-  CreateSavedQueryRequest,
-  UpdateSavedQueryRequest,
+  AddWidgetRequest,
   AnalyticsQueryRequest,
   AnalyticsQueryResult,
-  SchemaInfo,
   Chart,
+  ChartDataResponse,
   ChartListItem,
   CreateChartRequest,
-  UpdateChartRequest,
-  ChartDataResponse,
+  CreateDashboardRequest,
+  CreateSavedQueryRequest,
   Dashboard,
   DashboardListItem,
-  CreateDashboardRequest,
-  UpdateDashboardRequest,
-  AddWidgetRequest,
-  UpdateWidgetRequest,
   DashboardWidget,
+  SavedQuery,
+  SavedQueryListItem,
+  SchemaInfo,
+  UpdateChartRequest,
+  UpdateDashboardRequest,
+  UpdateSavedQueryRequest,
+  UpdateWidgetRequest,
 } from '../types/analytics';
 import type { PageResponse } from '../types/common';
+import { client } from './client';
 
 export const analyticsApi = {
   // ============================================================

--- a/apps/firehub-web/src/api/api-connections.ts
+++ b/apps/firehub-web/src/api/api-connections.ts
@@ -1,9 +1,9 @@
-import { client } from './client';
 import type {
   ApiConnectionResponse,
   CreateApiConnectionRequest,
   UpdateApiConnectionRequest,
 } from '../types/api-connection';
+import { client } from './client';
 
 export const apiConnectionsApi = {
   getAll: () =>

--- a/apps/firehub-web/src/api/auditLogs.ts
+++ b/apps/firehub-web/src/api/auditLogs.ts
@@ -1,6 +1,6 @@
-import { client } from './client';
 import type { AuditLogResponse } from '../types/auditLog';
 import type { PageResponse } from '../types/common';
+import { client } from './client';
 
 export const auditLogsApi = {
   getAuditLogs: (params: {

--- a/apps/firehub-web/src/api/auth.ts
+++ b/apps/firehub-web/src/api/auth.ts
@@ -1,10 +1,10 @@
+import type { LoginRequest, SignupRequest, TokenResponse, UserResponse } from '../types/auth';
 import { client } from './client';
-import type { SignupRequest, LoginRequest, TokenResponse, UserResponse } from '../types/auth';
 
 export const authApi = {
   signup: (data: SignupRequest) => client.post<UserResponse>('/auth/signup', data),
   login: (data: LoginRequest) => client.post<TokenResponse>('/auth/login', data),
   refresh: () => client.post<TokenResponse>('/auth/refresh'),
-  logout: () => client.post('/auth/logout'),
+  logout: () => client.post<void>('/auth/logout'),
   me: () => client.get<UserResponse>('/auth/me'),
 };

--- a/apps/firehub-web/src/api/dashboard.ts
+++ b/apps/firehub-web/src/api/dashboard.ts
@@ -1,5 +1,5 @@
-import { client } from './client';
 import type { DashboardStatsResponse } from '../types/dashboard';
+import { client } from './client';
 
 export const dashboardApi = {
   getStats: () => client.get<DashboardStatsResponse>('/dashboard/stats'),

--- a/apps/firehub-web/src/api/dataImports.ts
+++ b/apps/firehub-web/src/api/dataImports.ts
@@ -1,5 +1,5 @@
+import type { ColumnMappingEntry,ImportPreviewResponse, ImportResponse, ImportStartResponse, ImportValidateResponse } from '../types/dataImport';
 import { client } from './client';
-import type { ImportResponse, ImportStartResponse, ImportPreviewResponse, ImportValidateResponse, ColumnMappingEntry } from '../types/dataImport';
 
 export const dataImportsApi = {
   uploadFile: (datasetId: number, file: File, mappings?: ColumnMappingEntry[], importMode?: string) => {

--- a/apps/firehub-web/src/api/datasets.ts
+++ b/apps/firehub-web/src/api/datasets.ts
@@ -1,16 +1,16 @@
-import { client } from './client';
-import type {
-  CategoryResponse, CategoryRequest,
-  DatasetResponse, DatasetDetailResponse,
-  CreateDatasetRequest, UpdateDatasetRequest,
-  DatasetColumnResponse, AddColumnRequest, UpdateColumnRequest,
-  DataQueryResponse, DataDeleteResponse, ColumnStatsResponse,
-  FavoriteToggleResponse, UpdateStatusRequest,
-  SqlQueryResponse, QueryHistoryResponse,
-  RowDataResponse, CloneDatasetRequest,
-  ApiImportRequest, ApiImportResponse,
-} from '../types/dataset';
 import type { PageResponse } from '../types/common';
+import type {
+AddColumnRequest,   ApiImportRequest, ApiImportResponse,
+CategoryRequest,
+  CategoryResponse, CloneDatasetRequest,
+ColumnStatsResponse,
+  CreateDatasetRequest, DataDeleteResponse,   DataQueryResponse,   DatasetColumnResponse, DatasetDetailResponse,
+  DatasetResponse,   FavoriteToggleResponse, QueryHistoryResponse,
+  RowDataResponse,   SqlQueryResponse, UpdateColumnRequest,
+UpdateDatasetRequest,
+UpdateStatusRequest,
+} from '../types/dataset';
+import { client } from './client';
 
 export const categoriesApi = {
   getCategories: () => client.get<CategoryResponse[]>('/dataset-categories'),

--- a/apps/firehub-web/src/api/jobs.ts
+++ b/apps/firehub-web/src/api/jobs.ts
@@ -1,5 +1,5 @@
-import { client } from './client';
 import type { JobStatusResponse } from '../types/job';
+import { client } from './client';
 
 export const jobsApi = {
   getJobStatus: (jobId: string) =>

--- a/apps/firehub-web/src/api/permissions.ts
+++ b/apps/firehub-web/src/api/permissions.ts
@@ -1,5 +1,5 @@
-import { client } from './client';
 import type { PermissionResponse } from '../types/role';
+import { client } from './client';
 
 export const permissionsApi = {
   getPermissions: (category?: string) =>

--- a/apps/firehub-web/src/api/pipelines.ts
+++ b/apps/firehub-web/src/api/pipelines.ts
@@ -1,10 +1,10 @@
-import { client } from './client';
-import type {
-  PipelineResponse, PipelineDetailResponse, CreatePipelineRequest,
-  UpdatePipelineRequest, PipelineExecutionResponse, ExecutionDetailResponse,
-  TriggerResponse, TriggerEventResponse, CreateTriggerRequest, UpdateTriggerRequest,
-} from '../types/pipeline';
 import type { PageResponse } from '../types/common';
+import type {
+CreatePipelineRequest,
+CreateTriggerRequest, ExecutionDetailResponse,
+PipelineDetailResponse, PipelineExecutionResponse,   PipelineResponse, TriggerEventResponse,   TriggerResponse,   UpdatePipelineRequest, UpdateTriggerRequest,
+} from '../types/pipeline';
+import { client } from './client';
 
 export const pipelinesApi = {
   getPipelines: (params: { page?: number; size?: number }) =>

--- a/apps/firehub-web/src/api/roles.ts
+++ b/apps/firehub-web/src/api/roles.ts
@@ -1,5 +1,5 @@
+import type { CreateRoleRequest, RoleDetailResponse, RoleResponse, SetPermissionsRequest,UpdateRoleRequest } from '../types/role';
 import { client } from './client';
-import type { RoleResponse, RoleDetailResponse, CreateRoleRequest, UpdateRoleRequest, SetPermissionsRequest } from '../types/role';
 
 export const rolesApi = {
   getRoles: () => client.get<RoleResponse[]>('/roles'),

--- a/apps/firehub-web/src/api/settings.ts
+++ b/apps/firehub-web/src/api/settings.ts
@@ -1,5 +1,5 @@
-import { client } from './client';
 import type { SettingResponse, UpdateSettingsRequest } from '../types/settings';
+import { client } from './client';
 
 export const settingsApi = {
   getByPrefix: (prefix: string) =>

--- a/apps/firehub-web/src/api/users.ts
+++ b/apps/firehub-web/src/api/users.ts
@@ -1,7 +1,7 @@
-import { client } from './client';
-import type { UserDetailResponse, UpdateProfileRequest, ChangePasswordRequest, SetRolesRequest, SetActiveRequest } from '../types/user';
 import type { UserResponse } from '../types/auth';
 import type { PageResponse } from '../types/common';
+import type { ChangePasswordRequest, SetActiveRequest,SetRolesRequest, UpdateProfileRequest, UserDetailResponse } from '../types/user';
+import { client } from './client';
 
 export const usersApi = {
   getMe: () => client.get<UserDetailResponse>('/users/me'),

--- a/apps/firehub-web/src/components/AdminRoute.tsx
+++ b/apps/firehub-web/src/components/AdminRoute.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet } from 'react-router-dom';
+
 import { useAuth } from '../hooks/useAuth';
 
 export function AdminRoute() {

--- a/apps/firehub-web/src/components/ProtectedRoute.tsx
+++ b/apps/firehub-web/src/components/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet } from 'react-router-dom';
+
 import { useAuth } from '../hooks/useAuth';
 
 export function ProtectedRoute() {

--- a/apps/firehub-web/src/components/ai/AIChatPanel.tsx
+++ b/apps/firehub-web/src/components/ai/AIChatPanel.tsx
@@ -1,10 +1,11 @@
-import { useAI } from './AIProvider';
-import { MessageList } from './MessageList';
-import { ChatInput } from './ChatInput';
-import { SessionSwitcher } from './SessionSwitcher';
-import { Button } from '../ui/button';
-import { PanelRight, MessageCircle, Monitor, X, Sparkles } from 'lucide-react';
+import { MessageCircle, Monitor, PanelRight, Sparkles,X } from 'lucide-react';
+
 import type { AIMode } from '../../types/ai';
+import { Button } from '../ui/button';
+import { useAI } from './AIProvider';
+import { ChatInput } from './ChatInput';
+import { MessageList } from './MessageList';
+import { SessionSwitcher } from './SessionSwitcher';
 
 interface AIChatPanelProps {
   showModeSwitch?: boolean;

--- a/apps/firehub-web/src/components/ai/AIFloating.tsx
+++ b/apps/firehub-web/src/components/ai/AIFloating.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useCallback, useEffect,useRef, useState } from 'react';
+
 import { AIChatPanel } from './AIChatPanel';
 import { useAI } from './AIProvider';
 

--- a/apps/firehub-web/src/components/ai/AIFullScreen.tsx
+++ b/apps/firehub-web/src/components/ai/AIFullScreen.tsx
@@ -1,6 +1,6 @@
 import { AIChatPanel } from './AIChatPanel';
-import { AISessionSidebar } from './AISessionSidebar';
 import { useAI } from './AIProvider';
+import { AISessionSidebar } from './AISessionSidebar';
 
 export function AIFullScreen() {
   const { isOpen } = useAI();

--- a/apps/firehub-web/src/components/ai/AIProvider.tsx
+++ b/apps/firehub-web/src/components/ai/AIProvider.tsx
@@ -1,7 +1,8 @@
-import { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import type { AIMode, AIMessage } from '../../types/ai';
+import { createContext, useCallback, useContext, useEffect, useMemo,useState } from 'react';
+
 import { useAIChat } from '../../hooks/queries/useAIChat';
+import type { AIMessage,AIMode } from '../../types/ai';
 
 interface AIContextValue {
   isOpen: boolean;

--- a/apps/firehub-web/src/components/ai/AISessionSidebar.tsx
+++ b/apps/firehub-web/src/components/ai/AISessionSidebar.tsx
@@ -1,9 +1,10 @@
+import { MessageSquare,Plus, Trash2 } from 'lucide-react';
+
+import { useAISessions, useDeleteAISession } from '../../hooks/queries/useAIChat';
+import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { ScrollArea } from '../ui/scroll-area';
-import { Plus, Trash2, MessageSquare } from 'lucide-react';
-import { useAISessions, useDeleteAISession } from '../../hooks/queries/useAIChat';
 import { useAI } from './AIProvider';
-import { cn } from '../../lib/utils';
 
 export function AISessionSidebar() {
   const { currentSessionId, startNewSession, loadSession } = useAI();

--- a/apps/firehub-web/src/components/ai/AISidePanel.tsx
+++ b/apps/firehub-web/src/components/ai/AISidePanel.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback, useRef } from 'react';
+import { useCallback, useRef,useState } from 'react';
+
+import { cn } from '../../lib/utils';
 import { AIChatPanel } from './AIChatPanel';
 import { useAI } from './AIProvider';
-import { cn } from '../../lib/utils';
 
 const MIN_WIDTH = 320;
 const MAX_WIDTH = 600;

--- a/apps/firehub-web/src/components/ai/AIToggleButton.tsx
+++ b/apps/firehub-web/src/components/ai/AIToggleButton.tsx
@@ -1,5 +1,6 @@
-import { Button } from '../ui/button';
 import { Sparkles } from 'lucide-react';
+
+import { Button } from '../ui/button';
 import { useAI } from './AIProvider';
 
 export function AIToggleButton() {

--- a/apps/firehub-web/src/components/ai/ChatInput.tsx
+++ b/apps/firehub-web/src/components/ai/ChatInput.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef } from 'react';
+import { Send, StopCircle } from 'lucide-react';
 import type { KeyboardEvent } from 'react';
+import { useRef,useState } from 'react';
+
 import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
-import { Send, StopCircle } from 'lucide-react';
 
 interface ChatInputProps {
   onSend: (message: string) => void;

--- a/apps/firehub-web/src/components/ai/MessageBubble.tsx
+++ b/apps/firehub-web/src/components/ai/MessageBubble.tsx
@@ -1,15 +1,16 @@
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
-import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
-import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
-import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
-import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
-import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
 import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import type { AIMessage, AIToolCall } from '../../types/ai';
+import remarkGfm from 'remark-gfm';
+
 import { cn } from '../../lib/utils';
+import type { AIMessage, AIToolCall } from '../../types/ai';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 SyntaxHighlighter.registerLanguage('python', python);

--- a/apps/firehub-web/src/components/ai/MessageList.tsx
+++ b/apps/firehub-web/src/components/ai/MessageList.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
+
+import type { AIMessage } from '../../types/ai';
 import { MessageBubble } from './MessageBubble';
 import { ThinkingIndicator } from './ThinkingIndicator';
-import type { AIMessage } from '../../types/ai';
 
 interface MessageListProps {
   messages: AIMessage[];

--- a/apps/firehub-web/src/components/ai/SessionSwitcher.tsx
+++ b/apps/firehub-web/src/components/ai/SessionSwitcher.tsx
@@ -1,4 +1,9 @@
+import { ChevronDown, MessageSquare,Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+
+import { useAISessions, useDeleteAISession } from '../../hooks/queries/useAIChat';
+import { cn } from '../../lib/utils';
+import type { AISession } from '../../types/ai';
 import { Button } from '../ui/button';
 import {
   DropdownMenu,
@@ -7,10 +12,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import { Plus, ChevronDown, Trash2, MessageSquare } from 'lucide-react';
-import { useAISessions, useDeleteAISession } from '../../hooks/queries/useAIChat';
-import { cn } from '../../lib/utils';
-import type { AISession } from '../../types/ai';
 
 interface SessionSwitcherProps {
   currentSessionId?: string | null;

--- a/apps/firehub-web/src/components/ai/ThinkingIndicator.tsx
+++ b/apps/firehub-web/src/components/ai/ThinkingIndicator.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 const thinkingTexts = [
   '생각하는 중',

--- a/apps/firehub-web/src/components/analytics/AreaChartView.tsx
+++ b/apps/firehub-web/src/components/analytics/AreaChartView.tsx
@@ -1,13 +1,14 @@
 import {
-  AreaChart,
   Area,
-  XAxis,
-  YAxis,
+  AreaChart,
   CartesianGrid,
-  Tooltip,
   Legend,
   ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
 } from 'recharts';
+
 import type { ChartConfig } from '../../types/analytics';
 
 const DEFAULT_COLORS = [

--- a/apps/firehub-web/src/components/analytics/AxisConfigPanel.tsx
+++ b/apps/firehub-web/src/components/analytics/AxisConfigPanel.tsx
@@ -1,3 +1,5 @@
+import type { ChartConfig, ChartType } from '../../types/analytics';
+import { Checkbox } from '../ui/checkbox';
 import { Label } from '../ui/label';
 import {
   Select,
@@ -7,8 +9,6 @@ import {
   SelectValue,
 } from '../ui/select';
 import { Switch } from '../ui/switch';
-import { Checkbox } from '../ui/checkbox';
-import type { ChartConfig, ChartType } from '../../types/analytics';
 
 interface AxisConfigPanelProps {
   chartType: ChartType;

--- a/apps/firehub-web/src/components/analytics/BarChartView.tsx
+++ b/apps/firehub-web/src/components/analytics/BarChartView.tsx
@@ -1,13 +1,14 @@
 import {
-  BarChart,
   Bar,
-  XAxis,
-  YAxis,
+  BarChart,
   CartesianGrid,
-  Tooltip,
   Legend,
   ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
 } from 'recharts';
+
 import type { ChartConfig } from '../../types/analytics';
 
 const DEFAULT_COLORS = [

--- a/apps/firehub-web/src/components/analytics/ChartRenderer.tsx
+++ b/apps/firehub-web/src/components/analytics/ChartRenderer.tsx
@@ -1,7 +1,7 @@
-import type { ChartType, ChartConfig } from '../../types/analytics';
+import type { ChartConfig,ChartType } from '../../types/analytics';
+import { AreaChartView } from './AreaChartView';
 import { BarChartView } from './BarChartView';
 import { LineChartView } from './LineChartView';
-import { AreaChartView } from './AreaChartView';
 import { PieChartView } from './PieChartView';
 import { ScatterChartView } from './ScatterChartView';
 import { TableView } from './TableView';

--- a/apps/firehub-web/src/components/analytics/ChartTypeSelector.tsx
+++ b/apps/firehub-web/src/components/analytics/ChartTypeSelector.tsx
@@ -1,12 +1,15 @@
 import {
+  AreaChart,
   BarChart2,
+  Donut,
   LineChart,
   PieChart,
-  AreaChart,
   ScatterChart,
   Table2,
-  Donut,
 } from 'lucide-react';
+
+import { cn } from '../../lib/utils';
+import type { ChartType } from '../../types/analytics';
 import { Button } from '../ui/button';
 import {
   Tooltip,
@@ -14,8 +17,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '../ui/tooltip';
-import type { ChartType } from '../../types/analytics';
-import { cn } from '../../lib/utils';
 
 // Lucide doesn't have a Donut icon — reuse PieChart with a label
 // We'll use a custom approach with existing icons

--- a/apps/firehub-web/src/components/analytics/DashboardWidgetCard.tsx
+++ b/apps/firehub-web/src/components/analytics/DashboardWidgetCard.tsx
@@ -1,10 +1,11 @@
-import { X, Loader2 } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Loader2,X } from 'lucide-react';
+
+import { useChart,useChartData } from '../../hooks/queries/useAnalytics';
+import type { DashboardWidget } from '../../types/analytics';
 import { Button } from '../ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { ChartRenderer } from './ChartRenderer';
 import { WidgetErrorBoundary } from './WidgetErrorBoundary';
-import { useChartData, useChart } from '../../hooks/queries/useAnalytics';
-import type { DashboardWidget } from '../../types/analytics';
 
 interface DashboardWidgetCardProps {
   widget: DashboardWidget;

--- a/apps/firehub-web/src/components/analytics/LineChartView.tsx
+++ b/apps/firehub-web/src/components/analytics/LineChartView.tsx
@@ -1,13 +1,14 @@
 import {
-  LineChart,
+  CartesianGrid,
+  Legend,
   Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
 } from 'recharts';
+
 import type { ChartConfig } from '../../types/analytics';
 
 const DEFAULT_COLORS = [

--- a/apps/firehub-web/src/components/analytics/PieChartView.tsx
+++ b/apps/firehub-web/src/components/analytics/PieChartView.tsx
@@ -1,11 +1,12 @@
 import {
-  PieChart,
-  Pie,
   Cell,
-  Tooltip,
   Legend,
+  Pie,
+  PieChart,
   ResponsiveContainer,
+  Tooltip,
 } from 'recharts';
+
 import type { ChartConfig, ChartType } from '../../types/analytics';
 
 const DEFAULT_COLORS = [

--- a/apps/firehub-web/src/components/analytics/ScatterChartView.tsx
+++ b/apps/firehub-web/src/components/analytics/ScatterChartView.tsx
@@ -1,14 +1,15 @@
 import {
-  ScatterChart,
-  Scatter,
-  XAxis,
-  YAxis,
   CartesianGrid,
-  Tooltip,
   Legend,
   ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
   ZAxis,
 } from 'recharts';
+
 import type { ChartConfig } from '../../types/analytics';
 
 const DEFAULT_COLORS = [

--- a/apps/firehub-web/src/components/analytics/WidgetErrorBoundary.tsx
+++ b/apps/firehub-web/src/components/analytics/WidgetErrorBoundary.tsx
@@ -1,6 +1,7 @@
-import { Component } from 'react';
-import type { ReactNode, ErrorInfo } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import type { ErrorInfo,ReactNode } from 'react';
+import { Component } from 'react';
+
 import { Button } from '../ui/button';
 
 interface Props {

--- a/apps/firehub-web/src/components/layout/AppLayout.tsx
+++ b/apps/firehub-web/src/components/layout/AppLayout.tsx
@@ -1,46 +1,47 @@
-import { useState, lazy, Suspense } from 'react';
-import { Outlet, Link, useLocation } from 'react-router-dom';
-import { useAuth } from '../../hooks/useAuth';
-import { Skeleton } from '../ui/skeleton';
-import { Button } from '../ui/button';
-import { Separator } from '../ui/separator';
+import type { LucideIcon } from 'lucide-react';
 import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from '../ui/tooltip';
-import {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} from '../ui/collapsible';
-import { UserNav } from './UserNav';
-import {
-  Home,
-  Users,
-  Shield,
-  Menu,
-  X,
-  Database,
-  GitBranch,
-  Tag,
-  FileText,
+  BarChart3,
   Bot,
-  Plug,
-  ChevronsLeft,
   ChevronDown,
   ChevronRight,
+  ChevronsLeft,
+  Database,
+  FileText,
   Flame,
-  Search,
-  BarChart3,
+  GitBranch,
+  Home,
   LayoutDashboard,
+  Menu,
+  Plug,
+  Search,
   Settings,
+  Shield,
+  Tag,
+  Users,
+  X,
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import { lazy, Suspense,useState } from 'react';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
+import { useAuth } from '../../hooks/useAuth';
 import { cn } from '../../lib/utils';
 import { AIProvider, useAI } from '../ai/AIProvider';
 import { AIToggleButton } from '../ai/AIToggleButton';
+import { Button } from '../ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../ui/collapsible';
+import { Separator } from '../ui/separator';
+import { Skeleton } from '../ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
+import { UserNav } from './UserNav';
 
 const AISidePanel = lazy(() =>
   import('../ai/AISidePanel').then((mod) => ({ default: mod.AISidePanel }))

--- a/apps/firehub-web/src/components/layout/UserNav.tsx
+++ b/apps/firehub-web/src/components/layout/UserNav.tsx
@@ -1,6 +1,8 @@
+import { ChevronsUpDown,LogOut, User } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { User, LogOut, ChevronsUpDown } from 'lucide-react';
+
 import { useAuth } from '../../hooks/useAuth';
+import { cn } from '../../lib/utils';
 import { Avatar, AvatarFallback } from '../ui/avatar';
 import {
   DropdownMenu,
@@ -10,7 +12,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import { cn } from '../../lib/utils';
 
 function getInitials(name: string): string {
   return name.charAt(0).toUpperCase();

--- a/apps/firehub-web/src/hooks/AuthContext.tsx
+++ b/apps/firehub-web/src/hooks/AuthContext.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
+import { useCallback, useEffect, useMemo,useState } from 'react';
+
+import { authApi } from '../api/auth';
+import { setAccessToken } from '../api/client';
+import { usersApi } from '../api/users';
+import type { LoginFormData, SignupFormData } from '../lib/validations/auth';
 import type { UserResponse } from '../types/auth';
 import type { RoleResponse } from '../types/role';
-import type { LoginFormData, SignupFormData } from '../lib/validations/auth';
-import { authApi } from '../api/auth';
-import { usersApi } from '../api/users';
-import { setAccessToken } from '../api/client';
 import { AuthContext } from './auth-context-value';
 
 const AUTH_FLAG_KEY = 'hasSession';

--- a/apps/firehub-web/src/hooks/auth-context-value.ts
+++ b/apps/firehub-web/src/hooks/auth-context-value.ts
@@ -1,7 +1,8 @@
 import { createContext } from 'react';
+
+import type { LoginFormData, SignupFormData } from '../lib/validations/auth';
 import type { UserResponse } from '../types/auth';
 import type { RoleResponse } from '../types/role';
-import type { LoginFormData, SignupFormData } from '../lib/validations/auth';
 
 export interface AuthContextValue {
   user: UserResponse | null;

--- a/apps/firehub-web/src/hooks/queries/useAIChat.ts
+++ b/apps/firehub-web/src/hooks/queries/useAIChat.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback, useRef } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef,useState } from 'react';
+
 import { aiApi, streamAIChat } from '../../api/ai';
 import type { AIMessage, AIStreamEvent } from '../../types/ai';
 

--- a/apps/firehub-web/src/hooks/queries/useAnalytics.ts
+++ b/apps/firehub-web/src/hooks/queries/useAnalytics.ts
@@ -1,14 +1,15 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { analyticsApi } from '../../api/analytics';
 import type {
-  CreateSavedQueryRequest,
-  UpdateSavedQueryRequest,
+  AddWidgetRequest,
   AnalyticsQueryRequest,
   CreateChartRequest,
-  UpdateChartRequest,
   CreateDashboardRequest,
+  CreateSavedQueryRequest,
+  UpdateChartRequest,
   UpdateDashboardRequest,
-  AddWidgetRequest,
+  UpdateSavedQueryRequest,
   UpdateWidgetRequest,
 } from '../../types/analytics';
 

--- a/apps/firehub-web/src/hooks/queries/useApiConnections.ts
+++ b/apps/firehub-web/src/hooks/queries/useApiConnections.ts
@@ -1,4 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiConnectionsApi } from '../../api/api-connections';
 import type { CreateApiConnectionRequest, UpdateApiConnectionRequest } from '../../types/api-connection';
 

--- a/apps/firehub-web/src/hooks/queries/useAuditLogs.ts
+++ b/apps/firehub-web/src/hooks/queries/useAuditLogs.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { auditLogsApi } from '../../api/auditLogs';
 
 export function useAuditLogs(params: {

--- a/apps/firehub-web/src/hooks/queries/useDashboard.ts
+++ b/apps/firehub-web/src/hooks/queries/useDashboard.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { dashboardApi } from '../../api/dashboard';
 
 export function useDashboardStats() {

--- a/apps/firehub-web/src/hooks/queries/useDatasets.ts
+++ b/apps/firehub-web/src/hooks/queries/useDatasets.ts
@@ -1,8 +1,9 @@
-import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { datasetsApi, categoriesApi } from '../../api/datasets';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { dataImportsApi } from '../../api/dataImports';
-import type { ImportResponse, ImportStartResponse, ColumnMappingEntry, ImportMode } from '../../types/dataImport';
-import type { CloneDatasetRequest, ApiImportRequest } from '../../types/dataset';
+import { categoriesApi,datasetsApi } from '../../api/datasets';
+import type { ColumnMappingEntry, ImportMode,ImportResponse, ImportStartResponse } from '../../types/dataImport';
+import type { ApiImportRequest,CloneDatasetRequest } from '../../types/dataset';
 
 export function useCategories() {
   return useQuery({

--- a/apps/firehub-web/src/hooks/queries/useJobProgress.ts
+++ b/apps/firehub-web/src/hooks/queries/useJobProgress.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef,useState } from 'react';
+
 import { getAccessToken } from '../../api/client';
 import { jobsApi } from '../../api/jobs';
 import type { JobProgress } from '../../types/job';

--- a/apps/firehub-web/src/hooks/queries/usePipelines.ts
+++ b/apps/firehub-web/src/hooks/queries/usePipelines.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { pipelinesApi } from '../../api/pipelines';
-import type { UpdatePipelineRequest, PipelineExecutionResponse, CreateTriggerRequest, UpdateTriggerRequest } from '../../types/pipeline';
+import type { CreateTriggerRequest, PipelineExecutionResponse, UpdatePipelineRequest, UpdateTriggerRequest } from '../../types/pipeline';
 
 export function usePipelines(params: { page?: number; size?: number }) {
   return useQuery({

--- a/apps/firehub-web/src/hooks/queries/useUsers.ts
+++ b/apps/firehub-web/src/hooks/queries/useUsers.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { usersApi } from '../../api/users';
 
 export function useUsers(params: { search?: string; page?: number; size?: number }) {

--- a/apps/firehub-web/src/hooks/useAuth.tsx
+++ b/apps/firehub-web/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
-import { AuthContext } from './auth-context-value';
+
 import type { AuthContextValue } from './auth-context-value';
+import { AuthContext } from './auth-context-value';
 
 export function useAuth(): AuthContextValue {
   const context = useContext(AuthContext);

--- a/apps/firehub-web/src/hooks/useColumnStatsMap.ts
+++ b/apps/firehub-web/src/hooks/useColumnStatsMap.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+
 import { useColumnStats } from '@/hooks/queries/useDatasets';
 import type { ColumnStatsResponse } from '@/types/dataset';
 

--- a/apps/firehub-web/src/hooks/useDebounceValue.ts
+++ b/apps/firehub-web/src/hooks/useDebounceValue.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect,useState } from 'react';
 
 export function useDebounceValue<T>(value: T, delay: number = 300): T {
   const [debouncedValue, setDebouncedValue] = useState(value);

--- a/apps/firehub-web/src/lib/api-error.ts
+++ b/apps/firehub-web/src/lib/api-error.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { toast } from 'sonner';
+
 import type { ErrorResponse } from '@/types/auth';
 
 export function extractApiError(error: unknown, fallback: string): string {

--- a/apps/firehub-web/src/lib/utils.ts
+++ b/apps/firehub-web/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx"
+import { type ClassValue,clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/apps/firehub-web/src/main.tsx
+++ b/apps/firehub-web/src/main.tsx
@@ -1,7 +1,9 @@
+import './index.css'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import './index.css'
+
 import App from './App.tsx'
 
 const queryClient = new QueryClient({

--- a/apps/firehub-web/src/pages/HomePage.tsx
+++ b/apps/firehub-web/src/pages/HomePage.tsx
@@ -1,11 +1,12 @@
-import { useDashboardStats } from '../hooks/queries/useDashboard';
-import { useDashboards } from '../hooks/queries/useAnalytics';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
-import { Badge } from '../components/ui/badge';
-import { Skeleton } from '../components/ui/skeleton';
+import { Database, GitBranch, LayoutDashboard,Play, Upload } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
+
+import { Badge } from '../components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Skeleton } from '../components/ui/skeleton';
+import { useDashboards } from '../hooks/queries/useAnalytics';
+import { useDashboardStats } from '../hooks/queries/useDashboard';
 import { useAuth } from '../hooks/useAuth';
-import { Database, GitBranch, Upload, Play, LayoutDashboard } from 'lucide-react';
 import { getStatusBadgeVariant, getStatusLabel } from '../lib/formatters';
 
 export default function HomePage() {

--- a/apps/firehub-web/src/pages/LoginPage.tsx
+++ b/apps/firehub-web/src/pages/LoginPage.tsx
@@ -1,16 +1,17 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, Navigate } from 'react-router-dom';
-import { loginSchema } from '../lib/validations/auth';
-import type { LoginFormData } from '../lib/validations/auth';
-import { useAuth } from '../hooks/useAuth';
+
 import { Button } from '../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { useAuth } from '../hooks/useAuth';
+import type { LoginFormData } from '../lib/validations/auth';
+import { loginSchema } from '../lib/validations/auth';
 import type { ErrorResponse } from '../types/auth';
-import axios from 'axios';
 
 export default function LoginPage() {
   const { login, isAuthenticated } = useAuth();

--- a/apps/firehub-web/src/pages/ProfilePage.tsx
+++ b/apps/firehub-web/src/pages/ProfilePage.tsx
@@ -1,17 +1,19 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useAuth } from '../hooks/useAuth';
-import { usersApi } from '../api/users';
-import { updateProfileSchema, changePasswordSchema } from '../lib/validations/user';
-import type { UpdateProfileFormData, ChangePasswordFormData } from '../lib/validations/user';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
-import { Separator } from '../components/ui/separator';
-import { FormField } from '@/components/ui/form-field';
 import { toast } from 'sonner';
+
+import { FormField } from '@/components/ui/form-field';
 import { extractApiError } from '@/lib/api-error';
+
+import { usersApi } from '../api/users';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { Separator } from '../components/ui/separator';
+import { useAuth } from '../hooks/useAuth';
+import type { ChangePasswordFormData,UpdateProfileFormData } from '../lib/validations/user';
+import { changePasswordSchema,updateProfileSchema } from '../lib/validations/user';
 
 export default function ProfilePage() {
   const { user, refreshUser } = useAuth();

--- a/apps/firehub-web/src/pages/SignupPage.tsx
+++ b/apps/firehub-web/src/pages/SignupPage.tsx
@@ -1,15 +1,17 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, Navigate } from 'react-router-dom';
-import { signupSchema } from '../lib/validations/auth';
-import type { SignupFormData } from '../lib/validations/auth';
-import { useAuth } from '../hooks/useAuth';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+
 import { FormField } from '@/components/ui/form-field';
 import { extractApiError } from '@/lib/api-error';
+
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { useAuth } from '../hooks/useAuth';
+import type { SignupFormData } from '../lib/validations/auth';
+import { signupSchema } from '../lib/validations/auth';
 
 export default function SignupPage() {
   const { signup, isAuthenticated } = useAuth();

--- a/apps/firehub-web/src/pages/admin/AISettingsPage.tsx
+++ b/apps/firehub-web/src/pages/admin/AISettingsPage.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { Bot, RotateCcw,Save } from 'lucide-react';
+import { useCallback,useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { settingsApi } from '../../api/settings';
 import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
-import { Textarea } from '../../components/ui/textarea';
-import { Skeleton } from '../../components/ui/skeleton';
-import { Separator } from '../../components/ui/separator';
 import {
   Select,
   SelectContent,
@@ -13,9 +14,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
-import { toast } from 'sonner';
-import { settingsApi } from '../../api/settings';
-import { Bot, Save, RotateCcw } from 'lucide-react';
+import { Separator } from '../../components/ui/separator';
+import { Skeleton } from '../../components/ui/skeleton';
+import { Textarea } from '../../components/ui/textarea';
 import type { SettingResponse } from '../../types/settings';
 
 const MODEL_OPTIONS = [

--- a/apps/firehub-web/src/pages/admin/ApiConnectionDetailPage.tsx
+++ b/apps/firehub-web/src/pages/admin/ApiConnectionDetailPage.tsx
@@ -1,12 +1,16 @@
-import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useApiConnection, useUpdateApiConnection, useDeleteApiConnection } from '../../hooks/queries/useApiConnections';
-import type { UpdateApiConnectionRequest } from '../../types/api-connection';
+import { ArrowLeft } from 'lucide-react';
+import { useEffect,useState } from 'react';
+import { useNavigate,useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
+import { handleApiError } from '@/lib/api-error';
+
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
-import { Badge } from '../../components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import {
   Select,
   SelectContent,
@@ -16,10 +20,8 @@ import {
 } from '../../components/ui/select';
 import { Separator } from '../../components/ui/separator';
 import { Skeleton } from '../../components/ui/skeleton';
-import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
-import { ArrowLeft } from 'lucide-react';
-import { toast } from 'sonner';
-import { handleApiError } from '@/lib/api-error';
+import { useApiConnection, useDeleteApiConnection,useUpdateApiConnection } from '../../hooks/queries/useApiConnections';
+import type { UpdateApiConnectionRequest } from '../../types/api-connection';
 
 export default function ApiConnectionDetailPage() {
   const { id } = useParams<{ id: string }>();

--- a/apps/firehub-web/src/pages/admin/ApiConnectionListPage.tsx
+++ b/apps/firehub-web/src/pages/admin/ApiConnectionListPage.tsx
@@ -1,11 +1,24 @@
+import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useApiConnections, useCreateApiConnection, useDeleteApiConnection } from '../../hooks/queries/useApiConnections';
-import type { CreateApiConnectionRequest } from '../../types/api-connection';
+import { toast } from 'sonner';
+
+import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
+import { TableEmptyRow } from '@/components/ui/table-empty';
+import { TableSkeletonRows } from '@/components/ui/table-skeleton';
+import { handleApiError } from '@/lib/api-error';
+
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../../components/ui/dialog';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
-import { Badge } from '../../components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -20,19 +33,8 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '../../components/ui/dialog';
-import { TableSkeletonRows } from '@/components/ui/table-skeleton';
-import { TableEmptyRow } from '@/components/ui/table-empty';
-import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
-import { Plus, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { handleApiError } from '@/lib/api-error';
+import { useApiConnections, useCreateApiConnection, useDeleteApiConnection } from '../../hooks/queries/useApiConnections';
+import type { CreateApiConnectionRequest } from '../../types/api-connection';
 
 export default function ApiConnectionListPage() {
   const navigate = useNavigate();

--- a/apps/firehub-web/src/pages/admin/AuditLogListPage.tsx
+++ b/apps/firehub-web/src/pages/admin/AuditLogListPage.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { useAuditLogs } from '../../hooks/queries/useAuditLogs';
+
+import { SearchInput } from '@/components/ui/search-input';
+import { SimplePagination } from '@/components/ui/simple-pagination';
+import { TableEmptyRow } from '@/components/ui/table-empty';
+import { TableSkeletonRows } from '@/components/ui/table-skeleton';
+import { useDebounceValue } from '@/hooks/useDebounceValue';
+
 import { Badge } from '../../components/ui/badge';
 import {
   Select,
@@ -16,11 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { SearchInput } from '@/components/ui/search-input';
-import { TableSkeletonRows } from '@/components/ui/table-skeleton';
-import { TableEmptyRow } from '@/components/ui/table-empty';
-import { SimplePagination } from '@/components/ui/simple-pagination';
-import { useDebounceValue } from '@/hooks/useDebounceValue';
+import { useAuditLogs } from '../../hooks/queries/useAuditLogs';
 
 const ACTION_TYPES = [
   { value: 'CREATE', label: '생성' },

--- a/apps/firehub-web/src/pages/admin/RoleDetailPage.tsx
+++ b/apps/firehub-web/src/pages/admin/RoleDetailPage.tsx
@@ -1,25 +1,26 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { rolesApi } from '../../api/roles';
+import axios from 'axios';
+import { ArrowLeft } from 'lucide-react';
+import { useEffect, useMemo,useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate,useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
 import { permissionsApi } from '../../api/permissions';
-import type { RoleDetailResponse } from '../../types/role';
-import type { PermissionResponse } from '../../types/role';
-import { updateRoleSchema } from '../../lib/validations/role';
-import type { UpdateRoleFormData } from '../../lib/validations/role';
+import { rolesApi } from '../../api/roles';
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
-import { Input } from '../../components/ui/input';
-import { Label } from '../../components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Checkbox } from '../../components/ui/checkbox';
-import { Badge } from '../../components/ui/badge';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
 import { Separator } from '../../components/ui/separator';
 import { Skeleton } from '../../components/ui/skeleton';
-import { ArrowLeft } from 'lucide-react';
-import { toast } from 'sonner';
+import type { UpdateRoleFormData } from '../../lib/validations/role';
+import { updateRoleSchema } from '../../lib/validations/role';
 import type { ErrorResponse } from '../../types/auth';
-import axios from 'axios';
+import type { RoleDetailResponse } from '../../types/role';
+import type { PermissionResponse } from '../../types/role';
 
 export default function RoleDetailPage() {
   const { id } = useParams<{ id: string }>();

--- a/apps/firehub-web/src/pages/admin/RoleListPage.tsx
+++ b/apps/firehub-web/src/pages/admin/RoleListPage.tsx
@@ -1,21 +1,19 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Plus, Trash2 } from 'lucide-react';
+import { useCallback,useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
+import { FormField } from '@/components/ui/form-field';
+import { TableEmptyRow } from '@/components/ui/table-empty';
+import { TableSkeletonRows } from '@/components/ui/table-skeleton';
+import { extractApiError, handleApiError } from '@/lib/api-error';
+
 import { rolesApi } from '../../api/roles';
-import type { RoleResponse } from '../../types/role';
-import { createRoleSchema } from '../../lib/validations/role';
-import type { CreateRoleFormData } from '../../lib/validations/role';
-import { Button } from '../../components/ui/button';
-import { Input } from '../../components/ui/input';
 import { Badge } from '../../components/ui/badge';
-import {
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '../../components/ui/table';
+import { Button } from '../../components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -23,13 +21,17 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../../components/ui/dialog';
-import { TableSkeletonRows } from '@/components/ui/table-skeleton';
-import { TableEmptyRow } from '@/components/ui/table-empty';
-import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
-import { FormField } from '@/components/ui/form-field';
-import { Plus, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { extractApiError, handleApiError } from '@/lib/api-error';
+import { Input } from '../../components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/table';
+import type { CreateRoleFormData } from '../../lib/validations/role';
+import { createRoleSchema } from '../../lib/validations/role';
+import type { RoleResponse } from '../../types/role';
 
 export default function RoleListPage() {
   const navigate = useNavigate();

--- a/apps/firehub-web/src/pages/admin/UserDetailPage.tsx
+++ b/apps/firehub-web/src/pages/admin/UserDetailPage.tsx
@@ -1,21 +1,22 @@
-import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { usersApi } from '../../api/users';
+import axios from 'axios';
+import { ArrowLeft } from 'lucide-react';
+import { useEffect,useState } from 'react';
+import { useNavigate,useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
 import { rolesApi } from '../../api/roles';
-import type { UserDetailResponse } from '../../types/user';
-import type { RoleResponse } from '../../types/role';
+import { usersApi } from '../../api/users';
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
-import { Badge } from '../../components/ui/badge';
-import { Switch } from '../../components/ui/switch';
 import { Checkbox } from '../../components/ui/checkbox';
 import { Label } from '../../components/ui/label';
 import { Separator } from '../../components/ui/separator';
 import { Skeleton } from '../../components/ui/skeleton';
-import { ArrowLeft } from 'lucide-react';
-import { toast } from 'sonner';
+import { Switch } from '../../components/ui/switch';
 import type { ErrorResponse } from '../../types/auth';
-import axios from 'axios';
+import type { RoleResponse } from '../../types/role';
+import type { UserDetailResponse } from '../../types/user';
 
 export default function UserDetailPage() {
   const { id } = useParams<{ id: string }>();

--- a/apps/firehub-web/src/pages/admin/UserListPage.tsx
+++ b/apps/firehub-web/src/pages/admin/UserListPage.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useUsers } from '../../hooks/queries/useUsers';
+
+import { SearchInput } from '@/components/ui/search-input';
+import { SimplePagination } from '@/components/ui/simple-pagination';
+import { TableEmptyRow } from '@/components/ui/table-empty';
+import { TableSkeletonRows } from '@/components/ui/table-skeleton';
+import { useDebounceValue } from '@/hooks/useDebounceValue';
+
 import { Badge } from '../../components/ui/badge';
 import {
   Table,
@@ -10,11 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { SearchInput } from '@/components/ui/search-input';
-import { TableSkeletonRows } from '@/components/ui/table-skeleton';
-import { TableEmptyRow } from '@/components/ui/table-empty';
-import { SimplePagination } from '@/components/ui/simple-pagination';
-import { useDebounceValue } from '@/hooks/useDebounceValue';
+import { useUsers } from '../../hooks/queries/useUsers';
 
 export default function UserListPage() {
   const navigate = useNavigate();

--- a/apps/firehub-web/src/pages/analytics/ChartBuilderPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/ChartBuilderPage.tsx
@@ -1,13 +1,20 @@
-import { useState, useEffect, useCallback } from 'react';
+import { ArrowLeft, Loader2, Play,Save } from 'lucide-react';
+import { useCallback,useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import {
-  useSavedQueries,
-  useExecuteSavedQuery,
-  useChart,
-  useCreateChart,
-  useUpdateChart,
-} from '../../hooks/queries/useAnalytics';
+import { toast } from 'sonner';
+
+import { AxisConfigPanel } from '../../components/analytics/AxisConfigPanel';
+import { ChartRenderer } from '../../components/analytics/ChartRenderer';
+import { ChartTypeSelector } from '../../components/analytics/ChartTypeSelector';
 import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/dialog';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import {
@@ -17,24 +24,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
-import { Switch } from '../../components/ui/switch';
-import { Skeleton } from '../../components/ui/skeleton';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '../../components/ui/dialog';
 import { Separator } from '../../components/ui/separator';
-import { ArrowLeft, Save, Loader2, Play } from 'lucide-react';
-import { toast } from 'sonner';
+import { Skeleton } from '../../components/ui/skeleton';
+import { Switch } from '../../components/ui/switch';
+import {
+  useChart,
+  useCreateChart,
+  useExecuteSavedQuery,
+  useSavedQueries,
+  useUpdateChart,
+} from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
-import type { ChartType, ChartConfig } from '../../types/analytics';
-import { ChartRenderer } from '../../components/analytics/ChartRenderer';
-import { ChartTypeSelector } from '../../components/analytics/ChartTypeSelector';
-import { AxisConfigPanel } from '../../components/analytics/AxisConfigPanel';
+import type { ChartConfig,ChartType } from '../../types/analytics';
 
 // ============================================================
 // Auto chart type recommendation

--- a/apps/firehub-web/src/pages/analytics/ChartListPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/ChartListPage.tsx
@@ -1,8 +1,19 @@
+import {
+  BarChart2,
+  Pencil,
+  Plus,
+  Share2,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useCharts, useDeleteChart } from '../../hooks/queries/useAnalytics';
-import { Button } from '../../components/ui/button';
+import { toast } from 'sonner';
+
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
+import { SearchInput } from '../../components/ui/search-input';
+import { SimplePagination } from '../../components/ui/simple-pagination';
 import {
   Table,
   TableCell,
@@ -10,20 +21,10 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { SearchInput } from '../../components/ui/search-input';
-import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { TableEmptyRow } from '../../components/ui/table-empty';
-import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
-import { SimplePagination } from '../../components/ui/simple-pagination';
+import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { Tabs, TabsList, TabsTrigger } from '../../components/ui/tabs';
-import {
-  Plus,
-  Trash2,
-  Pencil,
-  BarChart2,
-  Share2,
-} from 'lucide-react';
-import { toast } from 'sonner';
+import { useCharts, useDeleteChart } from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
 import { formatDateShort } from '../../lib/formatters';
 import type { ChartType } from '../../types/analytics';

--- a/apps/firehub-web/src/pages/analytics/DashboardEditorPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/DashboardEditorPage.tsx
@@ -1,42 +1,43 @@
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { ResponsiveGridLayout, useContainerWidth } from 'react-grid-layout';
-import type { LayoutItem, ResponsiveLayouts } from 'react-grid-layout';
 import {
-  useDashboard,
-  useAddWidget,
-  useRemoveWidget,
-  useUpdateWidget,
-  useCharts,
-} from '../../hooks/queries/useAnalytics';
-import { Button } from '../../components/ui/button';
+  ArrowLeft,
+  Check,
+  LayoutDashboard,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  X,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef,useState } from 'react';
+import type { LayoutItem, ResponsiveLayouts } from 'react-grid-layout';
+import { ResponsiveGridLayout, useContainerWidth } from 'react-grid-layout';
+import { useNavigate,useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { DashboardWidgetCard } from '../../components/analytics/DashboardWidgetCard';
 import { Badge } from '../../components/ui/badge';
-import { Skeleton } from '../../components/ui/skeleton';
+import { Button } from '../../components/ui/button';
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from '../../components/ui/dialog';
+import { Skeleton } from '../../components/ui/skeleton';
 import {
-  ArrowLeft,
-  Pencil,
-  Check,
-  X,
-  Plus,
-  Maximize2,
-  Minimize2,
-  RefreshCw,
-  Loader2,
-  LayoutDashboard,
-} from 'lucide-react';
-import { toast } from 'sonner';
+  useAddWidget,
+  useCharts,
+  useDashboard,
+  useRemoveWidget,
+  useUpdateWidget,
+} from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
-import { DashboardWidgetCard } from '../../components/analytics/DashboardWidgetCard';
 import type { ChartListItem, DashboardWidget } from '../../types/analytics';
 
 // Sub-component that owns width measurement for ResponsiveGridLayout

--- a/apps/firehub-web/src/pages/analytics/DashboardListPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/DashboardListPage.tsx
@@ -1,10 +1,29 @@
+import {
+  LayoutDashboard,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Share2,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useDashboards, useDeleteDashboard } from '../../hooks/queries/useAnalytics';
-import { useCreateDashboard } from '../../hooks/queries/useAnalytics';
-import { Button } from '../../components/ui/button';
+import { toast } from 'sonner';
+
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/dialog';
 import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { SimplePagination } from '../../components/ui/simple-pagination';
+import { Switch } from '../../components/ui/switch';
 import {
   Table,
   TableCell,
@@ -12,30 +31,12 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { TableEmptyRow } from '../../components/ui/table-empty';
-import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
-import { SimplePagination } from '../../components/ui/simple-pagination';
+import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { Tabs, TabsList, TabsTrigger } from '../../components/ui/tabs';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '../../components/ui/dialog';
-import { Label } from '../../components/ui/label';
 import { Textarea } from '../../components/ui/textarea';
-import { Switch } from '../../components/ui/switch';
-import {
-  Plus,
-  Trash2,
-  Pencil,
-  LayoutDashboard,
-  Share2,
-  RefreshCw,
-} from 'lucide-react';
-import { toast } from 'sonner';
+import { useDashboards, useDeleteDashboard } from '../../hooks/queries/useAnalytics';
+import { useCreateDashboard } from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
 import { formatDateShort } from '../../lib/formatters';
 import type { CreateDashboardRequest } from '../../types/analytics';

--- a/apps/firehub-web/src/pages/analytics/QueryEditorPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/QueryEditorPage.tsx
@@ -1,22 +1,34 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import {
-  useSavedQuery,
-  useCreateSavedQuery,
-  useUpdateSavedQuery,
-  useExecuteAnalyticsQuery,
-  useSchemaInfo,
-  useQueryFolders,
-} from '../../hooks/queries/useAnalytics';
-import { EditorState } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
-import { sql, PostgreSQL } from '@codemirror/lang-sql';
-import { oneDark } from '@codemirror/theme-one-dark';
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
-import { searchKeymap } from '@codemirror/search';
 import { autocompletion } from '@codemirror/autocomplete';
-import { Button } from '../../components/ui/button';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { PostgreSQL,sql } from '@codemirror/lang-sql';
+import { searchKeymap } from '@codemirror/search';
+import { EditorState } from '@codemirror/state';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { EditorView, keymap } from '@codemirror/view';
+import {
+  ArrowLeft,
+  BarChart2,
+  ChevronDown,
+  ChevronRight,
+  Columns,
+  Loader2,
+  Play,
+  Save,
+  Table2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo,useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/dialog';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import {
@@ -26,30 +38,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '../../components/ui/dialog';
-import { Switch } from '../../components/ui/switch';
 import { Skeleton } from '../../components/ui/skeleton';
+import { Switch } from '../../components/ui/switch';
 import {
-  ArrowLeft,
-  Play,
-  Save,
-  ChevronRight,
-  ChevronDown,
-  BarChart2,
-  Loader2,
-  Table2,
-  Columns,
-} from 'lucide-react';
-import { toast } from 'sonner';
+  useCreateSavedQuery,
+  useExecuteAnalyticsQuery,
+  useQueryFolders,
+  useSavedQuery,
+  useSchemaInfo,
+  useUpdateSavedQuery,
+} from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
-import type { AnalyticsQueryResult, SchemaTable } from '../../types/analytics';
 import { cn } from '../../lib/utils';
+import type { AnalyticsQueryResult, SchemaTable } from '../../types/analytics';
 
 // ============================================================
 // Inline SQL Editor with schema-aware autocomplete

--- a/apps/firehub-web/src/pages/analytics/QueryListPage.tsx
+++ b/apps/firehub-web/src/pages/analytics/QueryListPage.tsx
@@ -1,13 +1,21 @@
+import {
+  BarChart2,
+  FileText,
+  Folder,
+  Pencil,
+  Play,
+  Plus,
+  Share2,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  useSavedQueries,
-  useDeleteSavedQuery,
-  useQueryFolders,
-  useExecuteSavedQuery,
-} from '../../hooks/queries/useAnalytics';
-import { Button } from '../../components/ui/button';
+import { toast } from 'sonner';
+
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
+import { SearchInput } from '../../components/ui/search-input';
 import {
   Select,
   SelectContent,
@@ -15,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
+import { SimplePagination } from '../../components/ui/simple-pagination';
 import {
   Table,
   TableCell,
@@ -22,23 +31,15 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { SearchInput } from '../../components/ui/search-input';
-import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { TableEmptyRow } from '../../components/ui/table-empty';
-import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
-import { SimplePagination } from '../../components/ui/simple-pagination';
+import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { Tabs, TabsList, TabsTrigger } from '../../components/ui/tabs';
 import {
-  Plus,
-  Trash2,
-  Pencil,
-  Play,
-  FileText,
-  Folder,
-  BarChart2,
-  Share2,
-} from 'lucide-react';
-import { toast } from 'sonner';
+  useDeleteSavedQuery,
+  useExecuteSavedQuery,
+  useQueryFolders,
+  useSavedQueries,
+} from '../../hooks/queries/useAnalytics';
 import { handleApiError } from '../../lib/api-error';
 import { formatDateShort } from '../../lib/formatters';
 

--- a/apps/firehub-web/src/pages/data/CategoryListPage.tsx
+++ b/apps/firehub-web/src/pages/data/CategoryListPage.tsx
@@ -1,14 +1,20 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
 import { z } from 'zod';
-import {
-  useCategories,
-  useCreateCategory,
-  useUpdateCategory,
-  useDeleteCategory,
-} from '../../hooks/queries/useDatasets';
+
 import { Button } from '../../components/ui/button';
+import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/dialog';
+import { FormField } from '../../components/ui/form-field';
 import { Input } from '../../components/ui/input';
 import {
   Table,
@@ -18,19 +24,14 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '../../components/ui/dialog';
-import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { TableEmptyRow } from '../../components/ui/table-empty';
-import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
-import { FormField } from '../../components/ui/form-field';
-import { Plus, Pencil, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { TableSkeletonRows } from '../../components/ui/table-skeleton';
+import {
+  useCategories,
+  useCreateCategory,
+  useDeleteCategory,
+  useUpdateCategory,
+} from '../../hooks/queries/useDatasets';
 import { handleApiError } from '../../lib/api-error';
 import type { CategoryResponse } from '../../types/dataset';
 

--- a/apps/firehub-web/src/pages/data/DatasetCreatePage.tsx
+++ b/apps/firehub-web/src/pages/data/DatasetCreatePage.tsx
@@ -1,13 +1,12 @@
-import { useNavigate } from 'react-router-dom';
-import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useCategories, useCreateDataset } from '../../hooks/queries/useDatasets';
-import { createDatasetSchema } from '../../lib/validations/dataset';
-import type { CreateDatasetFormData } from '../../lib/validations/dataset';
+import { FormProvider,useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
 import { Button } from '../../components/ui/button';
-import { Input } from '../../components/ui/input';
 import { Card } from '../../components/ui/card';
 import { FormField } from '../../components/ui/form-field';
+import { Input } from '../../components/ui/input';
 import {
   Select,
   SelectContent,
@@ -15,9 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
-import { SchemaBuilder } from './components/SchemaBuilder';
-import { toast } from 'sonner';
+import { useCategories, useCreateDataset } from '../../hooks/queries/useDatasets';
 import { handleApiError } from '../../lib/api-error';
+import type { CreateDatasetFormData } from '../../lib/validations/dataset';
+import { createDatasetSchema } from '../../lib/validations/dataset';
+import { SchemaBuilder } from './components/SchemaBuilder';
 
 export default function DatasetCreatePage() {
   const navigate = useNavigate();

--- a/apps/firehub-web/src/pages/data/DatasetDetailPage.tsx
+++ b/apps/firehub-web/src/pages/data/DatasetDetailPage.tsx
@@ -1,18 +1,8 @@
-import { useState, useEffect } from 'react';
+import { Copy,Plus, Shield, Star, X } from 'lucide-react';
+import { useEffect,useState } from 'react';
 import { useParams } from 'react-router-dom';
-import {
-  useDataset,
-  useCategories,
-  useToggleFavorite,
-  useUpdateStatus,
-  useAddTag,
-  useRemoveTag,
-  useTags,
-} from '../../hooks/queries/useDatasets';
-import { useRecentDatasets } from '../../hooks/useRecentDatasets';
-import { useAuth } from '../../hooks/useAuth';
-import { Skeleton } from '../../components/ui/skeleton';
-import { Tabs, TabsList, TabsTrigger } from '../../components/ui/tabs';
+import { toast } from 'sonner';
+
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
@@ -28,14 +18,25 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
-import { DatasetInfoTab } from './tabs/DatasetInfoTab';
+import { Skeleton } from '../../components/ui/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '../../components/ui/tabs';
+import {
+  useAddTag,
+  useCategories,
+  useDataset,
+  useRemoveTag,
+  useTags,
+  useToggleFavorite,
+  useUpdateStatus,
+} from '../../hooks/queries/useDatasets';
+import { useAuth } from '../../hooks/useAuth';
+import { useRecentDatasets } from '../../hooks/useRecentDatasets';
+import { CloneDatasetDialog } from './components/CloneDatasetDialog';
+import { LinkedPipelineStatus } from './components/LinkedPipelineStatus';
 import { DatasetColumnsTab } from './tabs/DatasetColumnsTab';
 import { DatasetDataTab } from './tabs/DatasetDataTab';
 import { DatasetHistoryTab } from './tabs/DatasetHistoryTab';
-import { Star, X, Plus, Shield, Copy } from 'lucide-react';
-import { toast } from 'sonner';
-import { CloneDatasetDialog } from './components/CloneDatasetDialog';
-import { LinkedPipelineStatus } from './components/LinkedPipelineStatus';
+import { DatasetInfoTab } from './tabs/DatasetInfoTab';
 
 export default function DatasetDetailPage() {
   const { id } = useParams();

--- a/apps/firehub-web/src/pages/data/DatasetListPage.tsx
+++ b/apps/firehub-web/src/pages/data/DatasetListPage.tsx
@@ -1,9 +1,13 @@
+import { BarChart3, Download,Eye, History, Plus, Star, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useDatasets, useCategories, useDeleteDataset, useToggleFavorite } from '../../hooks/queries/useDatasets';
-import { useRecentDatasets } from '../../hooks/useRecentDatasets';
-import { Button } from '../../components/ui/button';
+import { toast } from 'sonner';
+
+import { datasetsApi } from '../../api/datasets';
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
+import { SearchInput } from '../../components/ui/search-input';
 import {
   Select,
   SelectContent,
@@ -11,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../components/ui/select';
+import { SimplePagination } from '../../components/ui/simple-pagination';
 import {
   Table,
   TableCell,
@@ -18,18 +23,14 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { SearchInput } from '../../components/ui/search-input';
-import { TableSkeletonRows } from '../../components/ui/table-skeleton';
 import { TableEmptyRow } from '../../components/ui/table-empty';
-import { DeleteConfirmDialog } from '../../components/ui/delete-confirm-dialog';
-import { SimplePagination } from '../../components/ui/simple-pagination';
-import { Plus, Trash2, History, Star, Eye, BarChart3, Download } from 'lucide-react';
-import { toast } from 'sonner';
+import { TableSkeletonRows } from '../../components/ui/table-skeleton';
+import { useCategories, useDatasets, useDeleteDataset, useToggleFavorite } from '../../hooks/queries/useDatasets';
+import { useRecentDatasets } from '../../hooks/useRecentDatasets';
 import { handleApiError } from '../../lib/api-error';
 import { downloadCsv } from '../../lib/download';
 import { formatDateShort } from '../../lib/formatters';
 import { DatasetPreviewSheet } from './components/DatasetPreviewSheet';
-import { datasetsApi } from '../../api/datasets';
 
 function getRelativeTime(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();

--- a/apps/firehub-web/src/pages/data/components/AddRowDialog.tsx
+++ b/apps/firehub-web/src/pages/data/components/AddRowDialog.tsx
@@ -1,13 +1,14 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useAddRow } from '../../../hooks/queries/useDatasets';
-import type { DatasetColumnResponse } from '../../../types/dataset';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
-import { Button } from '../../../components/ui/button';
-import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
+
+import { Button } from '../../../components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { useAddRow } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { DatasetColumnResponse } from '../../../types/dataset';
 import { buildRowZodSchema, cleanFormValues } from './row-form-utils';
 import { RowFormFields } from './RowFormFields';
 

--- a/apps/firehub-web/src/pages/data/components/ApiImportWizard.tsx
+++ b/apps/firehub-web/src/pages/data/components/ApiImportWizard.tsx
@@ -1,19 +1,20 @@
+import { Loader2,Play, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { Play, Plus, Trash2, Loader2 } from 'lucide-react';
+
+import { client } from '@/api/client';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -21,9 +22,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { client } from '@/api/client';
+import { Textarea } from '@/components/ui/textarea';
 import { useCreateApiImport } from '@/hooks/queries/useDatasets';
 import type { DatasetColumnResponse } from '@/types/dataset';
+
 import ApiCallPreview from '../../pipeline/components/ApiCallPreview';
 
 interface ApiImportWizardProps {

--- a/apps/firehub-web/src/pages/data/components/CloneDatasetDialog.tsx
+++ b/apps/firehub-web/src/pages/data/components/CloneDatasetDialog.tsx
@@ -1,18 +1,19 @@
-import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { Loader2 } from 'lucide-react';
+import { Controller,useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { useCloneDataset } from '../../../hooks/queries/useDatasets';
-import type { DatasetDetailResponse } from '../../../types/dataset';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
 import { Button } from '../../../components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { Switch } from '../../../components/ui/switch';
 import { Textarea } from '../../../components/ui/textarea';
-import { Loader2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { useCloneDataset } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { DatasetDetailResponse } from '../../../types/dataset';
 
 interface CloneDatasetDialogProps {
   open: boolean;

--- a/apps/firehub-web/src/pages/data/components/CodeMirrorEditor.tsx
+++ b/apps/firehub-web/src/pages/data/components/CodeMirrorEditor.tsx
@@ -1,11 +1,11 @@
-import { useRef, useEffect } from 'react';
-import { EditorState } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
-import { sql, PostgreSQL } from '@codemirror/lang-sql';
-import { oneDark } from '@codemirror/theme-one-dark';
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
-import { searchKeymap } from '@codemirror/search';
 import { autocompletion } from '@codemirror/autocomplete';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { PostgreSQL,sql } from '@codemirror/lang-sql';
+import { searchKeymap } from '@codemirror/search';
+import { EditorState } from '@codemirror/state';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { EditorView, keymap } from '@codemirror/view';
+import { useEffect,useRef } from 'react';
 
 interface CodeMirrorEditorProps {
   value: string;

--- a/apps/firehub-web/src/pages/data/components/ColumnDialog.tsx
+++ b/apps/firehub-web/src/pages/data/components/ColumnDialog.tsx
@@ -1,21 +1,22 @@
-import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAddColumn } from '../../../hooks/queries/useDatasets';
+import { KeyRound } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
 import { datasetsApi } from '../../../api/datasets';
-import { addColumnSchema, updateColumnSchema } from '../../../lib/validations/dataset';
-import type { AddColumnFormData, UpdateColumnFormData } from '../../../lib/validations/dataset';
-import type { DatasetColumnResponse } from '../../../types/dataset';
 import { Button } from '../../../components/ui/button';
-import { Input } from '../../../components/ui/input';
-import { Label } from '../../../components/ui/label';
 import { Checkbox } from '../../../components/ui/checkbox';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
-import { ColumnTypeSelect } from './ColumnTypeSelect';
-import { KeyRound } from 'lucide-react';
-import { toast } from 'sonner';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
+import { useAddColumn } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { AddColumnFormData, UpdateColumnFormData } from '../../../lib/validations/dataset';
+import { addColumnSchema, updateColumnSchema } from '../../../lib/validations/dataset';
+import type { DatasetColumnResponse } from '../../../types/dataset';
+import { ColumnTypeSelect } from './ColumnTypeSelect';
 
 interface ColumnDialogProps {
   mode: 'add' | 'edit';

--- a/apps/firehub-web/src/pages/data/components/ColumnStats.tsx
+++ b/apps/firehub-web/src/pages/data/components/ColumnStats.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import type { ColumnStatsResponse } from '../../../types/dataset';
+
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '../../../components/ui/popover';
+import type { ColumnStatsResponse } from '../../../types/dataset';
 
 // Mini histogram for numeric columns
 export function NumericMiniChart({ stats }: { stats: ColumnStatsResponse }) {

--- a/apps/firehub-web/src/pages/data/components/DataTableToolbar.tsx
+++ b/apps/firehub-web/src/pages/data/components/DataTableToolbar.tsx
@@ -1,6 +1,7 @@
+import { Download, Globe,Plus, Terminal, Upload } from 'lucide-react';
+
 import { Button } from '../../../components/ui/button';
 import { SearchInput } from '../../../components/ui/search-input';
-import { Download, Upload, Terminal, Plus, Globe } from 'lucide-react';
 
 interface DataTableToolbarProps {
   dataSearch: string;

--- a/apps/firehub-web/src/pages/data/components/DatasetPreviewSheet.tsx
+++ b/apps/firehub-web/src/pages/data/components/DatasetPreviewSheet.tsx
@@ -1,14 +1,15 @@
-import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { datasetsApi } from '../../../api/datasets';
+import { Button } from '../../../components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '../../../components/ui/dialog';
-import { Button } from '../../../components/ui/button';
 import { Skeleton } from '../../../components/ui/skeleton';
-import { datasetsApi } from '../../../api/datasets';
 
 interface DatasetPreviewSheetProps {
   datasetId: number;

--- a/apps/firehub-web/src/pages/data/components/DescriptionCell.tsx
+++ b/apps/firehub-web/src/pages/data/components/DescriptionCell.tsx
@@ -1,10 +1,11 @@
+import { Loader2,Pencil } from 'lucide-react';
 import React, { useCallback } from 'react';
-import { useUpdateColumn } from '../../../hooks/queries/useDatasets';
-import type { DatasetColumnResponse } from '../../../types/dataset';
-import { Input } from '../../../components/ui/input';
-import { Pencil, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
+
+import { Input } from '../../../components/ui/input';
+import { useUpdateColumn } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { DatasetColumnResponse } from '../../../types/dataset';
 
 interface DescriptionCellProps {
   col: DatasetColumnResponse;

--- a/apps/firehub-web/src/pages/data/components/EditRowDialog.tsx
+++ b/apps/firehub-web/src/pages/data/components/EditRowDialog.tsx
@@ -1,13 +1,14 @@
-import { useMemo, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useUpdateRow } from '../../../hooks/queries/useDatasets';
-import type { DatasetColumnResponse } from '../../../types/dataset';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
-import { Button } from '../../../components/ui/button';
 import { Loader2 } from 'lucide-react';
+import { useEffect,useMemo } from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+
+import { Button } from '../../../components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { useUpdateRow } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { DatasetColumnResponse } from '../../../types/dataset';
 import { buildRowZodSchema, cleanFormValues } from './row-form-utils';
 import { RowFormFields } from './RowFormFields';
 

--- a/apps/firehub-web/src/pages/data/components/FileUploadZone.tsx
+++ b/apps/firehub-web/src/pages/data/components/FileUploadZone.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from 'react';
 import { Upload } from 'lucide-react';
+import { useCallback,useRef, useState } from 'react';
+
 import { cn } from '../../../lib/utils';
 
 interface FileUploadZoneProps {

--- a/apps/firehub-web/src/pages/data/components/ImportMappingDialog.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportMappingDialog.tsx
@@ -1,12 +1,13 @@
-import { useImportDialog } from '../hooks/useImportDialog';
-import type { DatasetColumnResponse } from '../../../types/dataset';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
-import { Button } from '../../../components/ui/button';
 import { Loader2 } from 'lucide-react';
+
+import { Button } from '../../../components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import type { DatasetColumnResponse } from '../../../types/dataset';
+import { useImportDialog } from '../hooks/useImportDialog';
 import { FileUploadZone } from './FileUploadZone';
-import { ImportProgressView } from './ImportProgressView';
 import { ImportMappingTable } from './ImportMappingTable';
 import { ImportModeSelector } from './ImportModeSelector';
+import { ImportProgressView } from './ImportProgressView';
 import { ImportSamplePreview } from './ImportSamplePreview';
 import { ImportValidationSection } from './ImportValidationSection';
 

--- a/apps/firehub-web/src/pages/data/components/ImportMappingTable.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportMappingTable.tsx
@@ -1,9 +1,10 @@
-import { Badge } from '../../../components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../components/ui/table';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../../components/ui/select';
 import { AlertTriangle, ArrowRight } from 'lucide-react';
+
+import { Badge } from '../../../components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../../components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../components/ui/table';
+import type { ColumnMappingDto,ColumnMappingEntry } from '../../../types/dataImport';
 import type { DatasetColumnResponse } from '../../../types/dataset';
-import type { ColumnMappingEntry, ColumnMappingDto } from '../../../types/dataImport';
 
 interface ImportMappingTableProps {
   suggestedMappings: ColumnMappingDto[];

--- a/apps/firehub-web/src/pages/data/components/ImportModeSelector.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportModeSelector.tsx
@@ -1,5 +1,6 @@
-import { RadioGroup, RadioGroupItem } from '../../../components/ui/radio-group';
 import { AlertTriangle, KeyRound } from 'lucide-react';
+
+import { RadioGroup, RadioGroupItem } from '../../../components/ui/radio-group';
 import type { ImportMode } from '../../../types/dataImport';
 
 interface ImportModeSelectorProps {

--- a/apps/firehub-web/src/pages/data/components/ImportProgressView.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportProgressView.tsx
@@ -1,4 +1,5 @@
-import { CheckCircle2, XCircle, Loader2, Clock } from 'lucide-react';
+import { CheckCircle2, Clock,Loader2, XCircle } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import type { ImportProgress } from '@/hooks/queries/useImportProgress';
 

--- a/apps/firehub-web/src/pages/data/components/ImportSamplePreview.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportSamplePreview.tsx
@@ -1,6 +1,6 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../components/ui/table';
+import type { ColumnMappingEntry,ImportPreviewResponse } from '../../../types/dataImport';
 import type { DatasetColumnResponse } from '../../../types/dataset';
-import type { ImportPreviewResponse, ColumnMappingEntry } from '../../../types/dataImport';
 
 interface ImportSamplePreviewProps {
   previewData: ImportPreviewResponse;

--- a/apps/firehub-web/src/pages/data/components/ImportValidationSection.tsx
+++ b/apps/firehub-web/src/pages/data/components/ImportValidationSection.tsx
@@ -1,7 +1,8 @@
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+
 import { Button } from '../../../components/ui/button';
 import { Card } from '../../../components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../components/ui/table';
-import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
 import type { ImportValidateResponse, ValidationErrorDetail } from '../../../types/dataImport';
 
 interface ImportValidationSectionProps {

--- a/apps/firehub-web/src/pages/data/components/LinkedPipelineStatus.tsx
+++ b/apps/firehub-web/src/pages/data/components/LinkedPipelineStatus.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+
 import { Badge } from '@/components/ui/badge';
 
 interface LinkedPipelineStatusProps {

--- a/apps/firehub-web/src/pages/data/components/RowFormFields.tsx
+++ b/apps/firehub-web/src/pages/data/components/RowFormFields.tsx
@@ -1,9 +1,10 @@
-import { Controller } from 'react-hook-form';
 import type { UseFormReturn } from 'react-hook-form';
-import type { DatasetColumnResponse } from '../../../types/dataset';
+import { Controller } from 'react-hook-form';
+
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { Switch } from '../../../components/ui/switch';
+import type { DatasetColumnResponse } from '../../../types/dataset';
 
 interface RowFormFieldsProps {
   columns: DatasetColumnResponse[];

--- a/apps/firehub-web/src/pages/data/components/SchemaBuilder.tsx
+++ b/apps/firehub-web/src/pages/data/components/SchemaBuilder.tsx
@@ -1,12 +1,13 @@
+import { KeyRound, Plus, X } from 'lucide-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
+
 import { Button } from '../../../components/ui/button';
-import { Input } from '../../../components/ui/input';
-import { Label } from '../../../components/ui/label';
 import { Card } from '../../../components/ui/card';
 import { Checkbox } from '../../../components/ui/checkbox';
-import { ColumnTypeSelect } from './ColumnTypeSelect';
-import { KeyRound, Plus, X } from 'lucide-react';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
 import type { CreateDatasetFormData } from '../../../lib/validations/dataset';
+import { ColumnTypeSelect } from './ColumnTypeSelect';
 
 export function SchemaBuilder() {
   const { control, register, setValue, watch, formState: { errors } } = useFormContext<CreateDatasetFormData>();

--- a/apps/firehub-web/src/pages/data/components/SqlQueryEditor.tsx
+++ b/apps/firehub-web/src/pages/data/components/SqlQueryEditor.tsx
@@ -1,14 +1,15 @@
-import { useState, useCallback, Suspense, lazy } from 'react';
+import axios from 'axios';
+import { AlertCircle, BarChart3,CheckCircle2, ExternalLink, Loader2, Play } from 'lucide-react';
+import { lazy,Suspense, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useExecuteQuery } from '../../../hooks/queries/useDatasets';
-import type { DatasetColumnResponse, SqlQueryResponse } from '../../../types/dataset';
+import { toast } from 'sonner';
+
+import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
 import { Card } from '../../../components/ui/card';
-import { Badge } from '../../../components/ui/badge';
-import { Play, Loader2, AlertCircle, CheckCircle2, ExternalLink, BarChart3 } from 'lucide-react';
-import { toast } from 'sonner';
-import axios from 'axios';
+import { useExecuteQuery } from '../../../hooks/queries/useDatasets';
 import type { ErrorResponse } from '../../../types/auth';
+import type { DatasetColumnResponse, SqlQueryResponse } from '../../../types/dataset';
 import { SqlQueryHistory } from './SqlQueryHistory';
 
 // Lazy-loaded CodeMirror wrapper for code splitting

--- a/apps/firehub-web/src/pages/data/components/SqlQueryHistory.tsx
+++ b/apps/firehub-web/src/pages/data/components/SqlQueryHistory.tsx
@@ -1,12 +1,13 @@
-import { useQueryHistory } from '../../../hooks/queries/useDatasets';
-import { Button } from '../../../components/ui/button';
+import { History, Loader2 } from 'lucide-react';
+
 import { Badge } from '../../../components/ui/badge';
+import { Button } from '../../../components/ui/button';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '../../../components/ui/popover';
-import { History, Loader2 } from 'lucide-react';
+import { useQueryHistory } from '../../../hooks/queries/useDatasets';
 import { formatDate } from '../../../lib/formatters';
 
 interface SqlQueryHistoryProps {

--- a/apps/firehub-web/src/pages/data/components/row-form-utils.ts
+++ b/apps/firehub-web/src/pages/data/components/row-form-utils.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import type { DatasetColumnResponse } from '../../../types/dataset';
 
 export function buildRowZodSchema(columns: DatasetColumnResponse[]) {

--- a/apps/firehub-web/src/pages/data/hooks/useColumnManager.ts
+++ b/apps/firehub-web/src/pages/data/hooks/useColumnManager.ts
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react';
-import { useDeleteColumn, useReorderColumns } from '../../../hooks/queries/useDatasets';
-import type { DatasetDetailResponse, DatasetColumnResponse } from '../../../types/dataset';
 import { toast } from 'sonner';
+
+import { useDeleteColumn, useReorderColumns } from '../../../hooks/queries/useDatasets';
 import { handleApiError } from '../../../lib/api-error';
+import type { DatasetColumnResponse,DatasetDetailResponse } from '../../../types/dataset';
 
 interface UseColumnManagerOptions {
   dataset: DatasetDetailResponse;

--- a/apps/firehub-web/src/pages/data/hooks/useColumnResize.ts
+++ b/apps/firehub-web/src/pages/data/hooks/useColumnResize.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef,useState } from 'react';
+
 import type { DatasetColumnResponse } from '../../../types/dataset';
 
 interface UseColumnResizeOptions {

--- a/apps/firehub-web/src/pages/data/hooks/useImportDialog.ts
+++ b/apps/firehub-web/src/pages/data/hooks/useImportDialog.ts
@@ -1,19 +1,20 @@
-import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
-import axios from 'axios';
 import { useQueryClient } from '@tanstack/react-query';
-import { usePreviewImport, useValidateImport, useUploadFile } from '../../../hooks/queries/useDatasets';
+import axios from 'axios';
+import { useEffect,useState } from 'react';
+import { toast } from 'sonner';
+
+import { usePreviewImport, useUploadFile,useValidateImport } from '../../../hooks/queries/useDatasets';
+import type { ImportProgress } from '../../../hooks/queries/useImportProgress';
 import { useImportProgress } from '../../../hooks/queries/useImportProgress';
 import { handleApiError } from '../../../lib/api-error';
-import type { DatasetColumnResponse } from '../../../types/dataset';
 import type {
-  ImportPreviewResponse,
   ColumnMappingEntry,
-  ImportValidateResponse,
   ImportMode,
+  ImportPreviewResponse,
+  ImportValidateResponse,
   ValidationErrorDetail,
 } from '../../../types/dataImport';
-import type { ImportProgress } from '../../../hooks/queries/useImportProgress';
+import type { DatasetColumnResponse } from '../../../types/dataset';
 
 interface UseImportDialogOptions {
   datasetId: number;

--- a/apps/firehub-web/src/pages/data/hooks/useInfiniteScrollSentinel.ts
+++ b/apps/firehub-web/src/pages/data/hooks/useInfiniteScrollSentinel.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useEffect,useRef } from 'react';
 
 interface UseInfiniteScrollSentinelOptions {
   hasNextPage: boolean | undefined;

--- a/apps/firehub-web/src/pages/data/hooks/useRowSelection.ts
+++ b/apps/firehub-web/src/pages/data/hooks/useRowSelection.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback,useState } from 'react';
 
 export function useRowSelection(allRowIds: number[]) {
   const [selectedRowIds, setSelectedRowIds] = useState<Set<number>>(new Set());

--- a/apps/firehub-web/src/pages/data/tabs/DatasetColumnsTab.tsx
+++ b/apps/firehub-web/src/pages/data/tabs/DatasetColumnsTab.tsx
@@ -1,19 +1,13 @@
-import React, { lazy, Suspense } from 'react';
-import type { DatasetDetailResponse, DatasetColumnResponse } from '../../../types/dataset';
-import { useColumnStatsMap } from '../../../hooks/useColumnStatsMap';
-import { useColumnManager } from '../hooks/useColumnManager';
-import { DescriptionCell } from '../components/DescriptionCell';
-import { DataTypeBadge } from '../components/DataTypeBadge';
-import { Button } from '../../../components/ui/button';
-import { Badge } from '../../../components/ui/badge';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '../../../components/ui/table';
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  KeyRound,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
+import React, { lazy, Suspense } from 'react';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -24,15 +18,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../../../components/ui/alert-dialog';
+import { Badge } from '../../../components/ui/badge';
+import { Button } from '../../../components/ui/button';
 import {
-  ChevronUp,
-  ChevronDown,
-  ChevronRight,
-  KeyRound,
-  Pencil,
-  Trash2,
-} from 'lucide-react';
-import { NullProgressBar, ColumnExpandedStats } from '../components/ColumnStats';
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../components/ui/table';
+import { useColumnStatsMap } from '../../../hooks/useColumnStatsMap';
+import type { DatasetColumnResponse,DatasetDetailResponse } from '../../../types/dataset';
+import { ColumnExpandedStats,NullProgressBar } from '../components/ColumnStats';
+import { DataTypeBadge } from '../components/DataTypeBadge';
+import { DescriptionCell } from '../components/DescriptionCell';
+import { useColumnManager } from '../hooks/useColumnManager';
 
 const ColumnDialog = lazy(() =>
   import('../components/ColumnDialog').then((m) => ({ default: m.ColumnDialog }))

--- a/apps/firehub-web/src/pages/data/tabs/DatasetDataTab.tsx
+++ b/apps/firehub-web/src/pages/data/tabs/DatasetDataTab.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo, lazy, Suspense, useRef, useEffect, useState, useCallback } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useDatasetData, useDeleteDataRows } from '../../../hooks/queries/useDatasets';
+import { ArrowDown, ArrowUp, ArrowUpDown, Loader2 } from 'lucide-react';
+import React, { lazy, Suspense, useCallback,useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
 import { dataImportsApi } from '../../../api/dataImports';
-import type { DatasetDetailResponse } from '../../../types/dataset';
-import { Card } from '../../../components/ui/card';
-import { Checkbox } from '../../../components/ui/checkbox';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,17 +14,19 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../../../components/ui/alert-dialog';
-import { ArrowUpDown, ArrowUp, ArrowDown, Loader2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { formatCellValue, isNullValue, getRawCellValue } from '../../../lib/formatters';
+import { Card } from '../../../components/ui/card';
+import { Checkbox } from '../../../components/ui/checkbox';
+import { useDatasetData, useDeleteDataRows } from '../../../hooks/queries/useDatasets';
+import { useColumnStatsMap } from '../../../hooks/useColumnStatsMap';
 import { handleApiError } from '../../../lib/api-error';
 import { downloadBlob } from '../../../lib/download';
-import { useColumnStatsMap } from '../../../hooks/useColumnStatsMap';
+import { formatCellValue, getRawCellValue,isNullValue } from '../../../lib/formatters';
+import type { DatasetDetailResponse } from '../../../types/dataset';
+import { DataTableToolbar } from '../components/DataTableToolbar';
+import { SelectionActionBar } from '../components/SelectionActionBar';
 import { useColumnResize } from '../hooks/useColumnResize';
 import { useInfiniteScrollSentinel } from '../hooks/useInfiniteScrollSentinel';
 import { useRowSelection } from '../hooks/useRowSelection';
-import { DataTableToolbar } from '../components/DataTableToolbar';
-import { SelectionActionBar } from '../components/SelectionActionBar';
 
 const ImportMappingDialog = lazy(() =>
   import('../components/ImportMappingDialog').then((m) => ({ default: m.ImportMappingDialog }))
@@ -35,10 +36,10 @@ const ApiImportWizard = lazy(() =>
   import('../components/ApiImportWizard').then((m) => ({ default: m.ApiImportWizard }))
 );
 
-import { SqlQueryEditor } from '../components/SqlQueryEditor';
 import { AddRowDialog } from '../components/AddRowDialog';
-import { EditRowDialog } from '../components/EditRowDialog';
 import { ColumnMiniChart } from '../components/ColumnStats';
+import { EditRowDialog } from '../components/EditRowDialog';
+import { SqlQueryEditor } from '../components/SqlQueryEditor';
 
 interface DatasetDataTabProps {
   dataset: DatasetDetailResponse;

--- a/apps/firehub-web/src/pages/data/tabs/DatasetHistoryTab.tsx
+++ b/apps/firehub-web/src/pages/data/tabs/DatasetHistoryTab.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
-import { useImports } from '../../../hooks/queries/useDatasets';
-import type { DatasetDetailResponse } from '../../../types/dataset';
+
 import { Badge } from '../../../components/ui/badge';
+import { useImports } from '../../../hooks/queries/useDatasets';
 import { formatDate, formatFileSize, getStatusBadgeVariant, getStatusLabel } from '../../../lib/formatters';
+import type { DatasetDetailResponse } from '../../../types/dataset';
 
 interface DatasetHistoryTabProps {
   dataset: DatasetDetailResponse;

--- a/apps/firehub-web/src/pages/data/tabs/DatasetInfoTab.tsx
+++ b/apps/firehub-web/src/pages/data/tabs/DatasetInfoTab.tsx
@@ -1,15 +1,15 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
+import { Clock,Columns, Database, Edit, Tag } from 'lucide-react';
 import React, { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useUpdateDataset } from '../../../hooks/queries/useDatasets';
-import { updateDatasetSchema } from '../../../lib/validations/dataset';
-import type { UpdateDatasetFormData } from '../../../lib/validations/dataset';
-import type { DatasetDetailResponse, CategoryResponse } from '../../../types/dataset';
+import { toast } from 'sonner';
+
+import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
+import { Card } from '../../../components/ui/card';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
-import { Badge } from '../../../components/ui/badge';
-import { Card } from '../../../components/ui/card';
 import {
   Select,
   SelectContent,
@@ -17,11 +17,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../../components/ui/select';
-import { Edit, Database, Columns, Tag, Clock } from 'lucide-react';
-import { toast } from 'sonner';
-import type { ErrorResponse } from '../../../types/auth';
-import axios from 'axios';
+import { useUpdateDataset } from '../../../hooks/queries/useDatasets';
 import { formatDate } from '../../../lib/formatters';
+import type { UpdateDatasetFormData } from '../../../lib/validations/dataset';
+import { updateDatasetSchema } from '../../../lib/validations/dataset';
+import type { ErrorResponse } from '../../../types/auth';
+import type { CategoryResponse,DatasetDetailResponse } from '../../../types/dataset';
 
 interface DatasetInfoTabProps {
   dataset: DatasetDetailResponse;

--- a/apps/firehub-web/src/pages/pipeline/PipelineEditorPage.tsx
+++ b/apps/firehub-web/src/pages/pipeline/PipelineEditorPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { Clock, Code, Database, Globe, Link, User } from 'lucide-react';
+import { useEffect, useMemo,useRef, useState } from 'react';
+import { useNavigate,useParams } from 'react-router-dom';
 import { toast } from 'sonner';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
@@ -12,17 +13,18 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { usePipelineEditor } from './hooks/usePipelineEditor';
-import { usePipeline, useExecution, useExecutePipeline, useExecutions } from '@/hooks/queries/usePipelines';
+import { Tabs, TabsContent,TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useDatasets } from '@/hooks/queries/useDatasets';
+import { useExecutePipeline, useExecution, useExecutions,usePipeline } from '@/hooks/queries/usePipelines';
 import { formatDate, getStatusBadgeVariant, getStatusLabel } from '@/lib/formatters';
+import type { PipelineExecutionResponse } from '@/types/pipeline';
+
 import { EditorHeader } from './components/EditorHeader';
+import { ExecutionStepPanel } from './components/ExecutionStepPanel';
 import { PipelineCanvas } from './components/PipelineCanvas';
 import StepConfigPanel from './components/StepConfigPanel';
-import { ExecutionStepPanel } from './components/ExecutionStepPanel';
 import TriggerTab from './components/TriggerTab';
-import { Clock, Code, Link, Globe, Database, User } from 'lucide-react';
-import type { PipelineExecutionResponse } from '@/types/pipeline';
+import { usePipelineEditor } from './hooks/usePipelineEditor';
 
 function formatDuration(startedAt: string | null, completedAt: string | null): string {
   if (!startedAt) return '-';

--- a/apps/firehub-web/src/pages/pipeline/PipelineListPage.tsx
+++ b/apps/firehub-web/src/pages/pipeline/PipelineListPage.tsx
@@ -1,8 +1,16 @@
+import { Clock,Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { usePipelines, useDeletePipeline } from '../../hooks/queries/usePipelines';
-import { Button } from '../../components/ui/button';
+import { toast } from 'sonner';
+
+import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
+import { SimplePagination } from '@/components/ui/simple-pagination';
+import { TableEmptyRow } from '@/components/ui/table-empty';
+import { TableSkeletonRows } from '@/components/ui/table-skeleton';
+import { handleApiError } from '@/lib/api-error';
+
 import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
 import {
   Table,
   TableBody,
@@ -10,13 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from '../../components/ui/table';
-import { TableSkeletonRows } from '@/components/ui/table-skeleton';
-import { TableEmptyRow } from '@/components/ui/table-empty';
-import { DeleteConfirmDialog } from '@/components/ui/delete-confirm-dialog';
-import { SimplePagination } from '@/components/ui/simple-pagination';
-import { Plus, Trash2, Clock } from 'lucide-react';
-import { toast } from 'sonner';
-import { handleApiError } from '@/lib/api-error';
+import { useDeletePipeline,usePipelines } from '../../hooks/queries/usePipelines';
 import { formatDateShort } from '../../lib/formatters';
 
 export default function PipelineListPage() {

--- a/apps/firehub-web/src/pages/pipeline/components/AddTriggerDialog.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/AddTriggerDialog.tsx
@@ -1,20 +1,22 @@
+import axios from 'axios';
+import { ArrowLeft,Clock, Code, Database, Globe, Link, Loader2 } from 'lucide-react';
 import { useState } from 'react';
-import { Clock, Code, Link, Globe, Database, Loader2, ArrowLeft } from 'lucide-react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { toast } from 'sonner';
+
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { toast } from 'sonner';
-import axios from 'axios';
-import type { ErrorResponse } from '@/types/auth';
-import type { TriggerType, TriggerResponse } from '@/types/pipeline';
 import { useCreateTrigger } from '@/hooks/queries/usePipelines';
-import ScheduleTriggerForm from './ScheduleTriggerForm';
+import type { ErrorResponse } from '@/types/auth';
+import type { TriggerResponse,TriggerType } from '@/types/pipeline';
+
 import ApiTriggerForm from './ApiTriggerForm';
-import PipelineChainForm from './PipelineChainForm';
-import WebhookTriggerForm from './WebhookTriggerForm';
 import DatasetChangeTriggerForm from './DatasetChangeTriggerForm';
+import PipelineChainForm from './PipelineChainForm';
+import ScheduleTriggerForm from './ScheduleTriggerForm';
+import WebhookTriggerForm from './WebhookTriggerForm';
 
 const TRIGGER_TYPES: { type: TriggerType; label: string; description: string; icon: React.ReactNode }[] = [
   { type: 'SCHEDULE', label: '스케줄', description: 'Cron 표현식으로 주기적 실행', icon: <Clock className="h-6 w-6" /> },

--- a/apps/firehub-web/src/pages/pipeline/components/ApiCallPreview.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ApiCallPreview.tsx
@@ -1,6 +1,7 @@
+import { ChevronDown, ChevronRight, Copy } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { ChevronDown, ChevronRight, Copy } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 

--- a/apps/firehub-web/src/pages/pipeline/components/ApiCallStepConfig.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ApiCallStepConfig.tsx
@@ -1,20 +1,26 @@
-import { useState } from 'react';
 import {
-  Globe,
-  Plus,
-  Trash2,
-  Play,
   ChevronDown,
   ChevronRight,
+  Globe,
   Key,
+  Play,
+  Plus,
   Settings2,
+  Trash2,
 } from 'lucide-react';
+import { useState } from 'react';
 import { toast } from 'sonner';
+
+import { client } from '@/api/client';
 import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Separator } from '@/components/ui/separator';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Select,
   SelectContent,
@@ -22,14 +28,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { client } from '@/api/client';
+import { Separator } from '@/components/ui/separator';
+import { Textarea } from '@/components/ui/textarea';
 import { useApiConnections } from '@/hooks/queries/useApiConnections';
+
 import ApiCallPreview from './ApiCallPreview';
 
 interface FieldMapping {

--- a/apps/firehub-web/src/pages/pipeline/components/ApiTriggerForm.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ApiTriggerForm.tsx
@@ -1,9 +1,10 @@
+import { AlertTriangle,Check, Copy } from 'lucide-react';
 import { useState } from 'react';
-import { Copy, Check, AlertTriangle } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 
 interface ApiTriggerFormProps {
   config: {

--- a/apps/firehub-web/src/pages/pipeline/components/CronExpressionInput.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/CronExpressionInput.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
-import cronstrue from 'cronstrue/i18n';
 import { CronExpressionParser } from 'cron-parser';
-import { Input } from '@/components/ui/input';
+import cronstrue from 'cronstrue/i18n';
+import { useMemo } from 'react';
+
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   Select,

--- a/apps/firehub-web/src/pages/pipeline/components/DatasetChangeTriggerForm.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/DatasetChangeTriggerForm.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
-import { Label } from '@/components/ui/label';
+
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useDatasets } from '@/hooks/queries/useDatasets';
+
 import DatasetCombobox from './DatasetCombobox';
 
 interface DatasetChangeTriggerFormProps {

--- a/apps/firehub-web/src/pages/pipeline/components/DatasetCombobox.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/DatasetCombobox.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Command,
   CommandEmpty,
@@ -9,8 +11,7 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
 interface DatasetOption {

--- a/apps/firehub-web/src/pages/pipeline/components/EditTriggerDialog.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/EditTriggerDialog.tsx
@@ -1,21 +1,23 @@
-import { useState } from 'react';
+import axios from 'axios';
 import { Loader2 } from 'lucide-react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
-import { toast } from 'sonner';
-import axios from 'axios';
+import { useUpdateTrigger } from '@/hooks/queries/usePipelines';
 import type { ErrorResponse } from '@/types/auth';
 import type { TriggerResponse } from '@/types/pipeline';
-import { useUpdateTrigger } from '@/hooks/queries/usePipelines';
-import ScheduleTriggerForm from './ScheduleTriggerForm';
+
 import ApiTriggerForm from './ApiTriggerForm';
-import PipelineChainForm from './PipelineChainForm';
-import WebhookTriggerForm from './WebhookTriggerForm';
 import DatasetChangeTriggerForm from './DatasetChangeTriggerForm';
+import PipelineChainForm from './PipelineChainForm';
+import ScheduleTriggerForm from './ScheduleTriggerForm';
+import WebhookTriggerForm from './WebhookTriggerForm';
 
 const TRIGGER_TYPE_LABELS: Record<string, string> = {
   SCHEDULE: '스케줄',

--- a/apps/firehub-web/src/pages/pipeline/components/EditorHeader.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/EditorHeader.tsx
@@ -1,20 +1,22 @@
+import { ArrowLeft, Pencil, Play, Save, X } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowLeft, Play, Save, Pencil, X } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+
 import {
   AlertDialog,
-  AlertDialogTrigger,
+  AlertDialogAction,
+  AlertDialogCancel,
   AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import type { PipelineEditorState, EditorAction } from '../hooks/usePipelineEditor';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import type { EditorAction,PipelineEditorState } from '../hooks/usePipelineEditor';
 
 interface EditorHeaderProps {
   state: PipelineEditorState;

--- a/apps/firehub-web/src/pages/pipeline/components/ExecutionStepPanel.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ExecutionStepPanel.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';

--- a/apps/firehub-web/src/pages/pipeline/components/PipelineCanvas.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/PipelineCanvas.tsx
@@ -1,21 +1,24 @@
 import '@xyflow/react/dist/style.css';
-import { useMemo, useCallback } from 'react';
+
 import {
-  ReactFlow,
   Background,
   Controls,
   type Edge,
+  type NodeMouseHandler,
   type OnConnect,
   type OnEdgesDelete,
-  type NodeMouseHandler,
   type OnNodeDrag,
+  ReactFlow,
 } from '@xyflow/react';
-import { Plus, LayoutGrid, Pencil } from 'lucide-react';
+import { LayoutGrid, Pencil,Plus } from 'lucide-react';
+import { useCallback,useMemo } from 'react';
+
 import { Button } from '@/components/ui/button';
-import type { PipelineEditorState, EditorAction } from '../hooks/usePipelineEditor';
 import type { ExecutionDetailResponse } from '@/types/pipeline';
-import { StepNode, type StepNodeData, type StepNodeType } from './StepNode';
+
+import type { EditorAction,PipelineEditorState } from '../hooks/usePipelineEditor';
 import { AddStepEdge } from './AddStepEdge';
+import { StepNode, type StepNodeData, type StepNodeType } from './StepNode';
 
 interface PipelineCanvasProps {
   state: PipelineEditorState;

--- a/apps/firehub-web/src/pages/pipeline/components/PipelineChainForm.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/PipelineChainForm.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
 import { Check, ChevronsUpDown } from 'lucide-react';
-import { Label } from '@/components/ui/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
 import {
   Command,
   CommandEmpty,
@@ -11,9 +10,11 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { usePipelines } from '@/hooks/queries/usePipelines';
+import { cn } from '@/lib/utils';
 import type { TriggerCondition } from '@/types/pipeline';
 
 interface PipelineChainFormProps {

--- a/apps/firehub-web/src/pages/pipeline/components/ScheduleTriggerForm.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ScheduleTriggerForm.tsx
@@ -1,7 +1,8 @@
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import CronExpressionInput from './CronExpressionInput';
 import type { ConcurrencyPolicy } from '@/types/pipeline';
+
+import CronExpressionInput from './CronExpressionInput';
 
 interface ScheduleTriggerFormProps {
   config: {

--- a/apps/firehub-web/src/pages/pipeline/components/ScriptEditor.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/ScriptEditor.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react';
-import { EditorView, lineNumbers, keymap } from '@codemirror/view';
-import { EditorState, Compartment } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
-import { bracketMatching } from '@codemirror/language';
-import { sql } from '@codemirror/lang-sql';
 import { python } from '@codemirror/lang-python';
+import { sql } from '@codemirror/lang-sql';
+import { bracketMatching } from '@codemirror/language';
+import { Compartment,EditorState } from '@codemirror/state';
+import { EditorView, keymap,lineNumbers } from '@codemirror/view';
+import { useEffect, useRef } from 'react';
 
 interface ScriptEditorProps {
   value: string;

--- a/apps/firehub-web/src/pages/pipeline/components/StepConfigPanel.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/StepConfigPanel.tsx
@@ -1,15 +1,11 @@
+import { Trash2,X } from 'lucide-react';
 import { lazy, Suspense } from 'react';
-import { X, Trash2 } from 'lucide-react';
 
 const ApiCallStepConfig = lazy(() => import('./ApiCallStepConfig'));
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -17,9 +13,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import DatasetCombobox from './DatasetCombobox';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
 import { formatDate } from '@/lib/formatters';
-import type { PipelineEditorState, EditorAction, EditorStep } from '../hooks/usePipelineEditor';
+
+import type { EditorAction, EditorStep,PipelineEditorState } from '../hooks/usePipelineEditor';
+import DatasetCombobox from './DatasetCombobox';
 
 const ScriptEditor = lazy(() => import('./ScriptEditor'));
 

--- a/apps/firehub-web/src/pages/pipeline/components/StepNode.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/StepNode.tsx
@@ -1,6 +1,6 @@
+import { Handle, type Node,type NodeProps, Position } from '@xyflow/react';
+import { CheckCircle2, Clock,FileCode, Globe, Loader2, Plus, SkipForward, Terminal, X, XCircle } from 'lucide-react';
 import { memo } from 'react';
-import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
-import { X, FileCode, Terminal, Globe, Plus, Loader2, CheckCircle2, XCircle, SkipForward, Clock } from 'lucide-react';
 
 export interface StepNodeData extends Record<string, unknown> {
   label: string;

--- a/apps/firehub-web/src/pages/pipeline/components/TriggerEventLog.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/TriggerEventLog.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+
 import { Badge } from '@/components/ui/badge';
 import {
   Table,
@@ -8,8 +9,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { formatDate } from '@/lib/formatters';
 import { useTriggerEvents } from '@/hooks/queries/usePipelines';
+import { formatDate } from '@/lib/formatters';
 import type { TriggerEventResponse } from '@/types/pipeline';
 
 function getEventBadgeVariant(eventType: TriggerEventResponse['eventType']) {

--- a/apps/firehub-web/src/pages/pipeline/components/TriggerTab.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/TriggerTab.tsx
@@ -1,16 +1,8 @@
+import axios from 'axios';
+import { Clock, Code, Database, Globe, Link, MoreHorizontal, Pencil, Plus, Power,Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Clock, Code, Link, Globe, Database, Plus, MoreHorizontal, Pencil, Trash2, Power } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { toast } from 'sonner';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,12 +13,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { toast } from 'sonner';
-import axios from 'axios';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { useDeleteTrigger, useToggleTrigger,useTriggers } from '@/hooks/queries/usePipelines';
+import { formatDate } from '@/lib/formatters';
 import type { ErrorResponse } from '@/types/auth';
 import type { TriggerResponse, TriggerType } from '@/types/pipeline';
-import { useTriggers, useDeleteTrigger, useToggleTrigger } from '@/hooks/queries/usePipelines';
-import { formatDate } from '@/lib/formatters';
+
 import { AddTriggerDialog } from './AddTriggerDialog';
 import { EditTriggerDialog } from './EditTriggerDialog';
 import TriggerEventLog from './TriggerEventLog';

--- a/apps/firehub-web/src/pages/pipeline/components/WebhookTriggerForm.tsx
+++ b/apps/firehub-web/src/pages/pipeline/components/WebhookTriggerForm.tsx
@@ -1,8 +1,9 @@
+import { AlertTriangle,Check, Copy } from 'lucide-react';
 import { useState } from 'react';
-import { Copy, Check, AlertTriangle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
 
 interface WebhookTriggerFormProps {
   config: {

--- a/apps/firehub-web/src/pages/pipeline/hooks/pipelineEditorReducer.ts
+++ b/apps/firehub-web/src/pages/pipeline/hooks/pipelineEditorReducer.ts
@@ -1,6 +1,7 @@
-import { getLayoutedElements } from '../utils/dagre-layout';
-import { wouldCreateCycle } from '../utils/cycle-detection';
 import type { PipelineDetailResponse } from '@/types/pipeline';
+
+import { wouldCreateCycle } from '../utils/cycle-detection';
+import { getLayoutedElements } from '../utils/dagre-layout';
 
 // === 공개 타입 ===
 

--- a/apps/firehub-web/src/pages/pipeline/hooks/usePipelineEditor.ts
+++ b/apps/firehub-web/src/pages/pipeline/hooks/usePipelineEditor.ts
@@ -1,11 +1,13 @@
-import { useReducer, useCallback, useRef } from 'react';
-import { pipelineEditorReducer, initialState } from './pipelineEditorReducer';
-import { usePipelineValidation } from './usePipelineValidation';
-import { usePipelineSave } from './usePipelineSave';
+import { useCallback, useReducer, useRef } from 'react';
+
 import type { PipelineDetailResponse } from '@/types/pipeline';
 
+import { initialState,pipelineEditorReducer } from './pipelineEditorReducer';
+import { usePipelineSave } from './usePipelineSave';
+import { usePipelineValidation } from './usePipelineValidation';
+
 // Re-export types so existing consumers don't need to change their imports
-export type { EditorStep, ValidationError, PipelineEditorState, EditorAction } from './pipelineEditorReducer';
+export type { EditorAction,EditorStep, PipelineEditorState, ValidationError } from './pipelineEditorReducer';
 
 export function usePipelineEditor(pipelineId?: number) {
   const [state, dispatch] = useReducer(pipelineEditorReducer, initialState);

--- a/apps/firehub-web/src/pages/pipeline/hooks/usePipelineSave.ts
+++ b/apps/firehub-web/src/pages/pipeline/hooks/usePipelineSave.ts
@@ -1,10 +1,12 @@
-import { useCallback } from 'react';
 import type { Dispatch } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { useCreatePipeline, useUpdatePipeline } from '@/hooks/queries/usePipelines';
 import type { PipelineStepRequest } from '@/types/pipeline';
-import type { PipelineEditorState, EditorAction } from './pipelineEditorReducer';
+
+import type { EditorAction,PipelineEditorState } from './pipelineEditorReducer';
 
 interface UsePipelineSaveOptions {
   state: PipelineEditorState;

--- a/apps/firehub-web/src/pages/pipeline/hooks/usePipelineValidation.ts
+++ b/apps/firehub-web/src/pages/pipeline/hooks/usePipelineValidation.ts
@@ -1,8 +1,10 @@
-import { useCallback } from 'react';
 import type { Dispatch } from 'react';
+import { useCallback } from 'react';
 import { toast } from 'sonner';
+
 import { editorPipelineSchema } from '@/lib/validations/pipeline';
-import type { PipelineEditorState, EditorAction, ValidationError } from './pipelineEditorReducer';
+
+import type { EditorAction, PipelineEditorState, ValidationError } from './pipelineEditorReducer';
 
 export function usePipelineValidation(
   state: PipelineEditorState,

--- a/apps/firehub-web/src/pages/pipeline/utils/dagre-layout.ts
+++ b/apps/firehub-web/src/pages/pipeline/utils/dagre-layout.ts
@@ -1,5 +1,5 @@
 import dagre from '@dagrejs/dagre';
-import type { Node, Edge } from '@xyflow/react';
+import type { Edge,Node } from '@xyflow/react';
 
 export function getLayoutedElements(
   nodes: Node[],

--- a/apps/firehub-web/vite.config.ts
+++ b/apps/firehub-web/vite.config.ts
@@ -1,8 +1,8 @@
-import path from 'path'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
 import { visualizer } from 'rollup-plugin-visualizer'
+import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,48 +5,45 @@
 
 ## P0 - 즉시 (24시간 이내)
 
-- [ ] **[Security/CRITICAL]** JWT Secret Key Git 노출 제거 및 키 재발급
-  - `application-local.yml:9` - 하드코딩된 JWT secret 제거
-  - Git history에서 secret 제거 (BFG Repo-Cleaner 권장)
-  - 환경변수(`JWT_SECRET`)로 이동
-  - 새로운 256-bit 이상 랜덤 키 생성: `openssl rand -base64 64`
+- [x] **[Security/CRITICAL]** JWT Secret Key Git 노출 제거 및 키 재발급
+  - `application-local.yml` — 환경변수 참조 + 개발용 기본값으로 변경 완료
+  - Git history 클린업(BFG)은 별도 작업
 
 ## P1 - 1주 이내
 
-- [ ] **[Security/HIGH]** CORS 설정 추가
-  - `SecurityConfig.java`에 `CorsConfigurationSource` 빈 추가
-  - 프로덕션 도메인만 허용하도록 설정
+- [x] **[Security/HIGH]** CORS 설정 추가
+  - `SecurityConfig.java`에 `CorsConfigurationSource` 빈 + `CorsProperties` 추가 완료
+  - 환경변수 `CORS_ALLOWED_ORIGINS`로 프로덕션 도메인 설정
 
-- [ ] **[Security/HIGH]** 로그인 실패 제한 구현 (Brute Force 방어)
-  - `LoginAttemptService` 생성 (5회 실패 시 15분 차단)
-  - Guava `LoadingCache` 또는 Bucket4j 사용
+- [x] **[Security/HIGH]** 로그인 실패 제한 구현 (Brute Force 방어)
+  - `LoginAttemptService` 생성 완료 (Caffeine 캐시, 5회 실패 시 15분 차단)
+  - `AccountLockedException` → HTTP 429 응답
 
 - [ ] **[Security/HIGH]** Refresh Token Rotation 구현
   - `AuthService.java:104-126`
   - Token family 관리 및 재사용 감지 시 전체 세션 폐기
   - `RefreshTokenRepository`에 `isTokenReused()`, `revokeTokenFamily()` 추가
 
-- [ ] **[Quality/HIGH]** 토큰 갱신 시 사용자 활성 상태 확인
-  - `AuthService.refresh()` 메서드에 `isActive` 체크 추가
+- [x] **[Quality/HIGH]** 토큰 갱신 시 사용자 활성 상태 확인
+  - `AuthService.refresh()`에 `isActive` 체크 추가 완료
   - 비활성 사용자는 `UserDeactivatedException` throw
 
 ## P2 - 2주 이내
 
-- [ ] **[Quality/CRITICAL]** 회원가입 Race Condition 수정
-  - `AuthService.java:62` - `countAll(null) == 0` 동시 가입 시 다수 ADMIN 생성 가능
-  - DB 제약조건 또는 비관적 락 사용
+- [x] **[Quality/CRITICAL]** 회원가입 Race Condition 수정
+  - PostgreSQL advisory lock (`pg_advisory_xact_lock`)으로 첫 사용자 판단 직렬화 완료
 
-- [ ] **[Quality/CRITICAL]** N+1 쿼리 성능 개선
-  - `UserRepository.setRoles()` (line 176-187) - 배치 INSERT로 변경
-  - `RoleRepository.setPermissions()` (line 95-106) - 배치 INSERT로 변경
+- [x] **[Quality/CRITICAL]** N+1 쿼리 성능 개선
+  - `UserRepository.setRoles()` — jOOQ multi-row INSERT로 변경 완료
+  - `RoleRepository.setPermissions()` — jOOQ multi-row INSERT로 변경 완료
 
-- [ ] **[Security/MEDIUM]** LIKE 패턴 이스케이프 처리
-  - `UserRepository.java:99-117`
-  - `%`, `_` 특수문자 이스케이프 메서드 추가
+- [x] **[Security/MEDIUM]** LIKE 패턴 이스케이프 처리
+  - `LikePatternUtils` 유틸리티 생성, 7개 레포지토리에 적용 완료
+  - `%`, `_`, `\` 특수문자 이스케이프 + jOOQ escape char 파라미터 사용
 
-- [ ] **[API/MEDIUM]** GlobalExceptionHandler에 일반 예외 핸들러 추가
-  - `Exception.class` catch-all 핸들러 추가
-  - 로깅 추가 (`LoggerFactory`)
+- [x] **[API/MEDIUM]** GlobalExceptionHandler에 일반 예외 핸들러 추가
+  - `Exception.class` catch-all 핸들러 추가 완료
+  - SLF4J Logger 추가, 고정 메시지로 내부 정보 미노출
 
 - [ ] **[API/MEDIUM]** ErrorResponse 강화
   - `ErrorResponse.java` - `timestamp`, `path` 필드 추가
@@ -61,8 +58,8 @@
 - [ ] **[Quality/MEDIUM]** AuthContext 무한 재렌더링 방지
   - `AuthContext.tsx:35-55` - cleanup 로직 추가, 의존성 배열 수정
 
-- [ ] **[Quality/MEDIUM]** 시스템 역할 권한 변경 보호
-  - `RoleService.java:46-55` - `setRolePermissions()`에 시스템 역할 체크 추가
+- [x] **[Quality/MEDIUM]** 시스템 역할 권한 변경 보호
+  - `RoleService.setRolePermissions()`에 `isSystem()` 가드 추가 완료
 
 - [ ] **[Quality/HIGH]** failedQueue 메모리 누수 방지
   - `client.ts:28-43` - 큐 크기 제한, 타임아웃 추가
@@ -106,10 +103,8 @@
   - 현재 min 8자만 요구
   - 대소문자, 숫자, 특수문자 포함 검증 추가
 
-- [ ] **[Security]** 보안 헤더 추가
-  - `X-Content-Type-Options: nosniff`
-  - `X-Frame-Options: DENY`
-  - `Strict-Transport-Security`
+- [x] **[Security]** 보안 헤더 추가
+  - `SecurityConfig.java`에 X-Content-Type-Options, X-Frame-Options, HSTS 설정 완료
 
 - [ ] **[Quality]** 만료된 Refresh Token 정리 배치 작업 구현
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.26(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@9.39.2(jiti@2.6.1))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -2670,6 +2673,11 @@ packages:
     resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
     peerDependencies:
       eslint: '>=8.40'
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -7132,6 +7140,10 @@ snapshots:
       - supports-color
 
   eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
 


### PR DESCRIPTION
B-1: JWT Secret Key 환경변수화
- application-local.yml: 하드코딩된 시크릿을 환경변수 참조(${JWT_SECRET:dev-default})로 변경
- encryption.master-key, agent.internal-token도 동일 패턴 적용

B-2: CORS 설정 추가
- CorsProperties record 신규 생성 (@ConfigurationProperties)
- SecurityConfig에 CorsConfigurationSource 빈 추가 (null-safe 처리)
- application.yml/local/prod/test에 CORS origin 프로퍼티 추가

B-3: 로그인 Brute-Force 방어
- LoginAttemptService 신규 생성 (Caffeine 캐시 기반, 5회 실패 → 15분 잠금)
- AccountLockedException 신규 생성 → 429 Too Many Requests 응답
- AuthService.login()에 시도 추적 로직 통합
- GlobalExceptionHandler에 AccountLockedException 핸들러 추가

B-4: Security 헤더 추가
- X-Content-Type-Options: nosniff
- X-Frame-Options: DENY
- Strict-Transport-Security: max-age=31536000; includeSubDomains

B-5: GlobalExceptionHandler catch-all 추가
- SLF4J Logger 추가 — 서버 로그에 전체 스택트레이스 기록
- Exception.class 핸들러 추가 — 클라이언트에는 고정 메시지만 노출

TC (7개 신규):
- LoginAttemptServiceTest: 5개 (차단/미차단/초기화/격리/경계값)
- GlobalExceptionHandlerTest: 2개 (429 잠금, 500 catch-all)
- AuthControllerTest: 1개 (429 반환)

https://claude.ai/code/session_011fJm1uasdeK3Rwh3dMPodX